### PR TITLE
[Feat]: #69 - implement draw_event streaming (ds/dm/de/un/er) with validation, docs, tick and 2-client test

### DIFF
--- a/config/socket.events.js
+++ b/config/socket.events.js
@@ -1,12 +1,13 @@
 const SOCKET_EVENTS = {
-  JOIN_ROOM: 'join-room',
-  JOIN_SUCCESS: 'join-success',
-  JOINED_ROOM: "joined-room",
-  TEACHER_SEND_DM: "teacher-send-dm",
-  RECEIVE_DM: "receive-dm",
-  SEND_MESSAGE: 'send-message',
-  RECEIVE_MESSAGE: 'receive-message',
-  ERROR: 'server-error',
+  JOIN_ROOM: 'join_room',
+  JOIN_SUCCESS: 'join_success',
+  JOINED_ROOM: "joined_room",
+  TEACHER_SEND_DM: "teacher_send_dm",
+  RECEIVE_DM: "receive_dm",
+  SEND_MESSAGE: 'send_message',
+  RECEIVE_MESSAGE: 'receive_message',
+  ERROR: 'server_error',
+  DRAW_EVENT: 'draw_event',
 };
 
 module.exports = { SOCKET_EVENTS };

--- a/docs/socket-events.md
+++ b/docs/socket-events.md
@@ -159,3 +159,110 @@
   "ts": 1706745600000
 }
 ```
+
+---
+
+## draw_event (판서 스트리밍)
+
+### 개요
+실시간 판서 데이터를 room 내 클라이언트에 브로드캐스트한다.
+모든 draw 이벤트는 `draw_event` 이름으로 송수신하며, `e` 필드로 이벤트 타입을 구분한다.
+
+### 이벤트 타입
+
+| e | 설명 | 필수 필드 |
+|---|------|----------|
+| `ds` | draw_start - 획 시작 | `sId`, `x`, `y`, `c`, `w` |
+| `dm` | draw_stream - 좌표 스트리밍 | `sId`, `x`, `y` |
+| `de` | draw_end - 획 종료 | `sId`, (선택) `pts` |
+| `un` | undo - 획 되돌리기 | `sId` |
+| `er` | eraser - 획 지우기 | `sId` |
+
+### Client -> Server
+
+- Event: `draw_event`
+- 조건: join된 상태에서만 전송 가능
+
+#### ds (draw_start)
+```json
+{
+  "e": "ds",
+  "sId": 1706745600000,
+  "x": 0.5,
+  "y": 0.3,
+  "c": "#FF0000",
+  "w": 2.5
+}
+```
+- `sId`: number - strokeId (타임스탬프 등 고유 값)
+- `x`, `y`: number - 정규화 좌표 (0~1 범위)
+- `c`: string - 색상 (hex 등)
+- `w`: number - 선 굵기 (0 초과)
+
+#### dm (draw_stream)
+```json
+{
+  "e": "dm",
+  "sId": 1706745600000,
+  "x": 0.52,
+  "y": 0.35
+}
+```
+- 고빈도 이벤트. 검증 실패 시 에러 없이 drop한다.
+- `x`, `y`: 0~1 범위
+
+#### de (draw_end)
+```json
+{
+  "e": "de",
+  "sId": 1706745600000,
+  "pts": [{"x":0.5,"y":0.3},{"x":0.52,"y":0.35}]
+}
+```
+- `pts`: (선택) 전체 좌표 배열. 전송 시 Array 타입이어야 한다.
+
+#### un (undo)
+```json
+{
+  "e": "un",
+  "sId": 1706745600000
+}
+```
+
+#### er (eraser)
+```json
+{
+  "e": "er",
+  "sId": 1706745600000
+}
+```
+
+### Server -> Client (room broadcast, sender 제외)
+
+- Event: `draw_event`
+- 서버가 추가하는 필드:
+
+```json
+{
+  "...payload",
+  "senderUserId": "u1",
+  "senderRole": "teacher",
+  "t": 42,
+  "ts": 1706745600000
+}
+```
+
+- `t`: number - room별 단조 증가 tick. 클라이언트는 이 값으로 이벤트 순서를 보장할 수 있다.
+  - 서버에서 부여하므로 클라이언트 간 시계 차이에 영향받지 않는다.
+  - room의 모든 소켓이 disconnect되면 tick은 초기화된다.
+
+### Validation 정책
+- `ds`: 모든 필수 필드 + 좌표 범위 검증. 실패 시 `PAYLOAD_INVALID` 에러.
+- `dm`: sId, x, y 타입 + 범위 검증. 실패 시 **에러 없이 drop** (고빈도 보호).
+- `de`: sId 필수, pts 전송 시 Array 타입 검증. 실패 시 `PAYLOAD_INVALID` 에러.
+- `un`, `er`: sId 필수. 실패 시 `PAYLOAD_INVALID` 에러.
+
+### Errors
+- `NOT_JOINED` - room 미참여
+- `PAYLOAD_INVALID` - 잘못된 payload
+- `ROOM_MISMATCH` - payload.r이 현재 room과 불일치

--- a/public/index.html
+++ b/public/index.html
@@ -59,20 +59,20 @@ socket.on('connect', () => {
   log(`서버 연결됨 (role=${role})`);
 });
 
-socket.on('receive-message', (msg) => {
-  log('💬 채팅: ' + msg);
+socket.on('receive_message', (data) => {
+  log('💬 채팅: ' + data.message + ' (' + data.sender.userId + ')');
 });
 
-socket.on('receive-dm', (data) => {
-  log('📢 DM: ' + data.message);
+socket.on('receive_dm', (data) => {
+  log('📢 DM: ' + data.message + ' (from: ' + data.senderUserId + ')');
 });
 
-  socket.on('join-success', (data) => {
+  socket.on('join_success', (data) => {
     showSuccess('✅ 입장 성공: ' + data.roomId);
     log('✅ 입장 성공: ' + data.roomId);
   });
 
-  socket.on('server-error', (err) => {
+  socket.on('server_error', (err) => {
     if (err.code === 'SESSION_NOT_FOUND') {
       showError('❌ 입장 거부: 존재하지 않는 세션입니다.');
       log('❌ 입장 거부: 존재하지 않는 세션');
@@ -94,14 +94,14 @@ socket.on('receive-dm', (data) => {
 
   const roomId = document.getElementById('roomId').value;
 
-  socket.emit('join-room', { roomId });
+  socket.emit('join_room', { roomId });
   log('방 입장 시도: ' + roomId);
 }
 
   function sendMsg() {
   const msg = document.getElementById('msg').value;
 
-  socket.emit('send-message', { msg });
+  socket.emit('send_message', { message: msg });
 
   // ✅ 내 화면에는 즉시 '보냄' 표시
   log('보냄(채팅): ' + msg);
@@ -110,7 +110,7 @@ socket.on('receive-dm', (data) => {
 
   function sendDM() {
     const message = document.getElementById('msg').value;
-    socket.emit('teacher-send-dm', { message });
+    socket.emit('teacher_send_dm', { message });
     log('📤 DM 전송: ' + message);
   }
 

--- a/scripts/genToken.js
+++ b/scripts/genToken.js
@@ -1,0 +1,11 @@
+require("dotenv").config();
+const { signToken } = require("../src/utils/jwt");
+
+const token = signToken({
+  userId: "teacher-test",
+  role: "teacher",
+});
+
+console.log("\n=== TEST TOKEN ===\n");
+console.log(token);
+console.log("\n==================\n");

--- a/scripts/printToken.js
+++ b/scripts/printToken.js
@@ -1,0 +1,10 @@
+require("dotenv").config();
+
+const t = process.env.TEST_TOKEN;
+if (!t) {
+  console.log("no token");
+  process.exit(0);
+}
+
+const payload = JSON.parse(Buffer.from(t.split(".")[1], "base64").toString());
+console.log(payload);

--- a/src/server.js
+++ b/src/server.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 const { logger } = require("./utils/logger");
 const { ERRORS } = require("../config/errors");
 const { sendHttpError } = require("./utils/httpError");
@@ -5,7 +7,6 @@ const { PrismaClient } = require('@prisma/client');
 const prisma = new PrismaClient();
 
 
-require('dotenv').config();
 if (process.env.NODE_ENV !== "production") {
   logger.info("env loaded", { key: "REDIS_URL" });
 }
@@ -22,6 +23,7 @@ const sessionStore = require('./store/sessionStore');
 const { signToken, verifyToken } = require('./utils/jwt');
 const { pubClient, subClient } = require("./lib/redisPubSub");
 const MAX_MESSAGE_LEN = 300;
+const VALID_DRAW_TYPES = new Set(["ds", "dm", "de", "un", "er"]);
 
 
 
@@ -36,6 +38,15 @@ function isValidMessage(msg) {
   return true;
 }
 
+
+// room별 draw tick 카운터 (순서 보장용)
+const roomDrawTick = new Map();
+
+function getNextTick(roomName) {
+  const t = (roomDrawTick.get(roomName) || 0) + 1;
+  roomDrawTick.set(roomName, t);
+  return t;
+}
 
 // ✅ 가드 헬퍼 함수
 function requireTeacher(socket) {
@@ -735,9 +746,98 @@ socket.on(SOCKET_EVENTS.SEND_MESSAGE, async (payload) => {
   });
 });
 
+socket.on(SOCKET_EVENTS.DRAW_EVENT, (payload) => {
+  if (!requireJoined(socket)) {
+    return socket.emit(SOCKET_EVENTS.ERROR, {
+      code: ERRORS.NOT_JOINED,
+      message: "NOT_JOINED",
+    });
+  }
+
+  if (!payload || !VALID_DRAW_TYPES.has(payload.e)) {
+    return socket.emit(SOCKET_EVENTS.ERROR, {
+      code: ERRORS.PAYLOAD_INVALID,
+      message: "INVALID_DRAW_EVENT",
+    });
+  }
+
+  const roomId = payload.r || socket.data.roomId;
+  if (roomId !== socket.data.roomId) {
+    return socket.emit(SOCKET_EVENTS.ERROR, {
+      code: ERRORS.PAYLOAD_INVALID,
+      message: "ROOM_MISMATCH",
+    });
+  }
+
+  const { e } = payload;
+
+  if (e === "ds") {
+    if (typeof payload.sId !== "number" ||
+        typeof payload.x !== "number" || payload.x < 0 || payload.x > 1 ||
+        typeof payload.y !== "number" || payload.y < 0 || payload.y > 1 ||
+        typeof payload.c !== "string" || !payload.c ||
+        typeof payload.w !== "number" || payload.w <= 0) {
+      return socket.emit(SOCKET_EVENTS.ERROR, {
+        code: ERRORS.PAYLOAD_INVALID,
+        message: "INVALID_DS_PAYLOAD",
+      });
+    }
+  }
+
+  if (e === "dm") {
+    if (typeof payload.sId !== "number" ||
+        typeof payload.x !== "number" || payload.x < 0 || payload.x > 1 ||
+        typeof payload.y !== "number" || payload.y < 0 || payload.y > 1) {
+      return; // drop: 고빈도 이벤트이므로 에러 응답 생략
+    }
+  }
+
+  if (e === "de") {
+    if (typeof payload.sId !== "number") {
+      return socket.emit(SOCKET_EVENTS.ERROR, {
+        code: ERRORS.PAYLOAD_INVALID,
+        message: "INVALID_DE_PAYLOAD",
+      });
+    }
+    if (payload.pts !== undefined) {
+      if (!Array.isArray(payload.pts)) {
+        return socket.emit(SOCKET_EVENTS.ERROR, {
+          code: ERRORS.PAYLOAD_INVALID,
+          message: "INVALID_DE_PAYLOAD",
+        });
+      }
+    }
+  }
+
+  if (e === "un" || e === "er") {
+    if (typeof payload.sId !== "number") {
+      return socket.emit(SOCKET_EVENTS.ERROR, {
+        code: ERRORS.PAYLOAD_INVALID,
+        message: e === "un" ? "INVALID_UN_PAYLOAD" : "INVALID_ER_PAYLOAD",
+      });
+    }
+  }
+
+  socket.to(socket.currentRoom).emit(SOCKET_EVENTS.DRAW_EVENT, {
+    ...payload,
+    senderUserId: socket.data.userId,
+    senderRole: socket.data.role,
+    t: getNextTick(socket.currentRoom),
+    ts: Date.now(),
+  });
+});
+
+
   // ✅ disconnect
   socket.on("disconnect", () => {
     logger.info("socket disconnected", { socketId: socket.id });
+    // room에 아무도 없으면 tick 카운터 정리
+    if (socket.currentRoom) {
+      const room = io.sockets.adapter.rooms.get(socket.currentRoom);
+      if (!room || room.size === 0) {
+        roomDrawTick.delete(socket.currentRoom);
+      }
+    }
   });
 });
 

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -7,7 +7,12 @@ function signToken(payload) {
 }
 
 function verifyToken(token) {
-  return jwt.verify(token, process.env.JWT_SECRET);
+  try {
+    return jwt.verify(token, process.env.JWT_SECRET);
+  } catch (e) {
+    console.log("JWT_VERIFY_FAIL:", e.name, e.message);
+    throw e;
+  }
 }
 
 module.exports = { signToken, verifyToken };

--- a/teacherClient.js
+++ b/teacherClient.js
@@ -1,32 +1,101 @@
+require("dotenv").config();
 const { io } = require("socket.io-client");
 
-const sessionId = "33a1f7e7-4d8d-4d3b-be25-c6fe0636bc7c";
+const sessionId = process.argv[2] || "31fa1c35-90b7-4d6c-9bb8-dda3e9d04544";
+const classId = process.argv[3] || "cml3irfbx0002uvtjvazqiv3z";
 const token = process.env.TEST_TOKEN;
 
-const socket = io("http://localhost:4000", {
+console.log("TEST_TOKEN exists?", !!token, token?.slice(0, 20));
+console.log("sessionId:", sessionId);
+
+const socket = io("http://localhost:3000", {
   auth: { token },
 });
 
 socket.on("connect", () => {
-  console.log("✅ teacher connected:", socket.id);
-
-  socket.emit("join-room", { roomId: sessionId });
-
-  // join 후 1초 뒤 DM 전송
-  setTimeout(() => {
-    socket.emit("teacher-send-dm", { message: "hello from teacher client" });
-    console.log("✉️ teacher-send-dm emitted");
-  }, 1000);
+  console.log("[teacher] connected:", socket.id);
+  socket.emit("join_room", { roomId: sessionId, classId });
 });
 
-socket.on("join-success", (data) => {
-  console.log("✅ teacher join-success:", data);
+socket.on("join_success", (data) => {
+  console.log("[teacher] join_success:", data);
+
+  const strokeId = Date.now();
+
+  // ds: draw_start
+  setTimeout(() => {
+    socket.emit("draw_event", {
+      e: "ds",
+      sId: strokeId,
+      x: 0.1,
+      y: 0.2,
+      c: "#FF0000",
+      w: 2.5,
+    });
+    console.log("[teacher] ds emitted, sId:", strokeId);
+  }, 300);
+
+  // dm: draw_stream (3 points)
+  const points = [
+    { x: 0.15, y: 0.25 },
+    { x: 0.2, y: 0.3 },
+    { x: 0.25, y: 0.35 },
+  ];
+  points.forEach((pt, i) => {
+    setTimeout(() => {
+      socket.emit("draw_event", {
+        e: "dm",
+        sId: strokeId,
+        x: pt.x,
+        y: pt.y,
+      });
+      console.log(`[teacher] dm emitted (${i + 1}/${points.length})`);
+    }, 400 + i * 100);
+  });
+
+  // de: draw_end
+  setTimeout(() => {
+    socket.emit("draw_event", {
+      e: "de",
+      sId: strokeId,
+      pts: [
+        { x: 0.1, y: 0.2 },
+        { x: 0.15, y: 0.25 },
+        { x: 0.2, y: 0.3 },
+        { x: 0.25, y: 0.35 },
+      ],
+    });
+    console.log("[teacher] de emitted");
+  }, 800);
+
+  // un: undo
+  setTimeout(() => {
+    socket.emit("draw_event", { e: "un", sId: strokeId });
+    console.log("[teacher] un emitted, sId:", strokeId);
+  }, 1000);
+
+  // er: eraser
+  const eraserStrokeId = Date.now() + 1;
+  setTimeout(() => {
+    socket.emit("draw_event", { e: "er", sId: eraserStrokeId });
+    console.log("[teacher] er emitted, sId:", eraserStrokeId);
+  }, 1200);
+
+  // done
+  setTimeout(() => {
+    console.log("[teacher] all draw events sent. exiting.");
+    process.exit(0);
+  }, 1500);
+});
+
+socket.on("draw_event", (payload) => {
+  console.log("[teacher] received draw_event:", payload);
+});
+
+socket.on("server_error", (e) => {
+  console.log("[teacher] server_error:", e);
 });
 
 socket.on("connect_error", (err) => {
-  console.log("❌ connect_error:", err.message);
-});
-
-socket.on("error", (e) => {
-  console.log("❌ error event:", e);
+  console.log("[teacher] connect_error:", err.message);
 });

--- a/testClient.js
+++ b/testClient.js
@@ -1,28 +1,64 @@
+require("dotenv").config();
 const { io } = require("socket.io-client");
 
-const sessionId = "33a1f7e7-4d8d-4d3b-be25-c6fe0636bc7c";
+const sessionId = process.argv[2] || "31fa1c35-90b7-4d6c-9bb8-dda3e9d04544";
+const classId = process.argv[3] || "cml3irfbx0002uvtjvazqiv3z";
 const token = process.env.TEST_TOKEN;
 
-const socket = io("http://localhost:4001", {
+console.log("TEST_TOKEN exists?", !!token, token?.slice(0, 20));
+console.log("sessionId:", sessionId);
+
+const socket = io("http://localhost:3000", {
   auth: { token },
 });
 
+let drawEventCount = 0;
+const expectedEvents = ["ds", "dm", "dm", "dm", "de", "un", "er"];
+const receivedEvents = [];
+const ticks = [];
+
 socket.on("connect", () => {
-  console.log("✅ connected:", socket.id);
-
-  // ⚠️ 이벤트명이 다르면 여기 3개를 socket.events 값으로 바꿔야 함
-  socket.emit("join-room", { roomId: sessionId });
+  console.log("[student] connected:", socket.id);
+  socket.emit("join_room", { roomId: sessionId, classId });
 });
 
-socket.on("join-success", (data) => {
-  console.log("✅ join-success:", data);
+socket.on("join_success", (data) => {
+  console.log("[student] join_success:", data);
+  console.log("[student] waiting for draw events...");
 });
 
-socket.on("receive-dm", (payload) => {
-  console.log("📩 receive-dm:", payload);
+socket.on("draw_event", (payload) => {
+  drawEventCount++;
+  receivedEvents.push(payload.e);
+  ticks.push(payload.t);
+  console.log(`[student] draw_event #${drawEventCount} (${payload.e}) t=${payload.t}:`, JSON.stringify(payload));
+});
+
+socket.on("receive_dm", (payload) => {
+  console.log("[student] receive_dm:", payload);
+});
+
+socket.on("server_error", (e) => {
+  console.log("[student] server_error:", e);
 });
 
 socket.on("connect_error", (err) => {
-  console.log("❌ connect_error:", err.message);
+  console.log("[student] connect_error:", err.message);
 });
 
+setTimeout(() => {
+  console.log("\n--- Summary ---");
+  console.log(`received ${drawEventCount} draw events`);
+  console.log("event types:", receivedEvents.join(" -> "));
+  console.log("expected:   ", expectedEvents.join(" -> "));
+  const eventsMatch = JSON.stringify(receivedEvents) === JSON.stringify(expectedEvents);
+  console.log("events match:", eventsMatch ? "OK" : "MISMATCH");
+
+  const ticksOrdered = ticks.every((v, i) => i === 0 || v > ticks[i - 1]);
+  console.log("ticks:", ticks.join(", "));
+  console.log("ticks ordered:", ticksOrdered ? "OK" : "FAIL");
+
+  const allPass = eventsMatch && ticksOrdered;
+  console.log("result:", allPass ? "ALL PASS" : "FAIL");
+  process.exit(allPass ? 0 : 1);
+}, 10000);


### PR DESCRIPTION
## 🛠 Summary

실시간 판서 이벤트(draw_event)를 Socket.IO 기반으로 구현하였습니다.

ds/dm/de/un/er 이벤트를 room 기반으로 브로드캐스트하며,
payload validation, 순서 보장 tick(t), 2-클라이언트 테스트까지 완료하였습니다.

---

## ✨ 주요 구현 내용

### 1. draw_event 스트리밍 구현
- draw_start (ds)
- draw_stream (dm)
- draw_end (de)
- undo (un)
- eraser (er)

모든 이벤트는 `draw_event`로 수신/전파하며 `e` 필드로 타입 구분합니다.

---

### 2. Payload Validation 강화
- ds: sId/x/y(0~1)/c/w 필수 검증
- dm: sId/x/y 타입 + 좌표 범위 검증 (실패 시 drop 전략)
- de: sId 필수 + pts 배열 타입 검증
- un/er: sId 필수 검증
- room mismatch 보호

---

### 3. Room 기반 전파
- join된 사용자만 전송 가능
- 동일 room 내에서 sender 제외 브로드캐스트

---

### 4. 순서 보장 tick(t) 추가
- room별 단조 증가 tick 부여
- 클라이언트는 t 값으로 이벤트 순서 보장 가능
- room이 비면 tick 초기화

---

### 5. 테스트
- teacherClient → ds → dm(3회) → de → un → er 전송
- studentClient 수신 검증
- 이벤트 순서 및 tick 증가 확인 (ALL PASS)

---

## 📚 Docs
- docs/socket-events.md에 draw_event 스펙 추가
- validation 정책 및 에러 코드 명시

---

## 🔍 검증 결과
- 2클라이언트 송수신 정상 동작
- tick 단조 증가 확인
- payload inval
