### PR TITLE
feat: #30 - complete subject & tag system with filtering API, indexin…

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -96,14 +96,16 @@ Authorization: Bearer <token>
 |------|------|------|
 | classId | O | 반(Class) ID |
 | subjectId | X | 과목(Subject) ID |
+| tagId | X | 태그(Tag) ID |
 | keyword | X | 검색 키워드 (type, url 기준 부분 검색) |
 
 ### Request 예시
 ```
 GET /materials?classId=CLASS_ID
 GET /materials?classId=CLASS_ID&subjectId=SUBJECT_ID
+GET /materials?classId=CLASS_ID&tagId=TAG_ID
 GET /materials?classId=CLASS_ID&keyword=pdf
-GET /materials?classId=CLASS_ID&subjectId=SUBJECT_ID&keyword=sample
+GET /materials?classId=CLASS_ID&subjectId=SUBJECT_ID&tagId=TAG_ID&keyword=sample
 ```
 
 ### Response 200
@@ -117,10 +119,10 @@ GET /materials?classId=CLASS_ID&subjectId=SUBJECT_ID&keyword=sample
       "classId": "cml3irfbx0002uvtjvazqiv3z",
       "createdAt": "2026-02-02T06:30:29.605Z",
       "subjects": [
-        {
-          "id": "b3cb5b75-4655-4be9-b1b5-fb051464b4e9",
-          "name": "Math"
-        }
+        { "id": "SUBJECT_ID", "name": "Math" }
+      ],
+      "tags": [
+        { "id": "TAG_ID", "name": "중요" }
       ]
     }
   ],
@@ -131,6 +133,7 @@ GET /materials?classId=CLASS_ID&subjectId=SUBJECT_ID&keyword=sample
 - `items`: 조건에 맞는 material 목록 (최대 50개, 최신순)
 - `count`: 반환된 결과 개수
 - `subjects`: material에 연결된 과목 목록
+- `tags`: material에 연결된 태그 목록
 
 ### Errors
 | HTTP | code | message | 설명 |
@@ -145,4 +148,174 @@ GET /materials?classId=CLASS_ID&subjectId=SUBJECT_ID&keyword=sample
 ### Performance Note
 - `(classId, createdAt)` 복합 인덱스로 반별 최신순 조회 최적화
 - `MaterialSubject(subjectId, materialId)` 인덱스로 과목 필터 최적화
+- `MaterialTag(tagId, materialId)` 인덱스로 태그 필터 최적화
 - EXPLAIN ANALYZE 기준 실행 시간 약 0.3ms
+
+---
+
+## Tag API
+
+### 설계 결정 사항
+
+- Subject는 **과목(교육과정 단위)** 태그로, Material에만 연결됩니다 (Class 연결 없음).
+- Tag는 **자유 형식 다중 태그**로, Subject와 독립적으로 Material에 부여할 수 있습니다.
+- 두 태그 체계를 분리하여 확장성을 확보합니다.
+
+---
+
+## POST /tags
+
+### 목적
+새 태그를 생성한다. **교사만 가능.**
+
+### Request Body
+```json
+{ "name": "중요" }
+```
+
+### Response 201
+```json
+{ "id": "TAG_ID", "name": "중요", "createdAt": "..." }
+```
+
+### Errors
+| HTTP | code | message |
+|------|------|---------|
+| 400 | PAYLOAD_INVALID | INVALID_TAG_NAME |
+| 409 | PAYLOAD_INVALID | DUPLICATE_TAG |
+
+---
+
+## GET /tags
+
+### 목적
+전체 태그 목록을 이름 오름차순으로 반환한다. **인증 필요 (교사/학생 모두 가능).**
+
+### Response 200
+```json
+[
+  { "id": "TAG_ID", "name": "중요", "createdAt": "..." }
+]
+```
+
+---
+
+## GET /tags/:tagId
+
+### Response 200
+```json
+{ "id": "TAG_ID", "name": "중요", "createdAt": "..." }
+```
+
+### Errors
+| HTTP | code | message |
+|------|------|---------|
+| 404 | PAYLOAD_INVALID | TAG_NOT_FOUND |
+
+---
+
+## GET /tags/:tagId
+
+> **인증 필요 (교사/학생 모두 가능)**
+
+## PUT /tags/:tagId
+
+> **교사만 가능**
+
+### Request Body
+```json
+{ "name": "매우중요" }
+```
+
+### Response 200
+```json
+{ "id": "TAG_ID", "name": "매우중요", "createdAt": "..." }
+```
+
+### Errors
+| HTTP | code | message |
+|------|------|---------|
+| 400 | PAYLOAD_INVALID | INVALID_TAG_NAME |
+| 404 | PAYLOAD_INVALID | TAG_NOT_FOUND |
+| 409 | PAYLOAD_INVALID | DUPLICATE_TAG |
+
+---
+
+## DELETE /tags/:tagId
+
+> **교사만 가능**
+
+### Response 200
+```json
+{ "ok": true, "tagId": "TAG_ID" }
+```
+
+### Errors
+| HTTP | code | message |
+|------|------|---------|
+| 404 | PAYLOAD_INVALID | TAG_NOT_FOUND |
+
+---
+
+## POST /materials/:materialId/tags
+
+### 목적
+수업자료에 태그를 추가한다. 여러 개를 한 번에 추가 가능하며, 중복은 무시된다.
+
+### Request Body
+```json
+{ "tagIds": ["TAG_ID_1", "TAG_ID_2"] }
+```
+
+### Response 200
+```json
+{
+  "materialId": "MATERIAL_ID",
+  "tags": [
+    { "id": "TAG_ID_1", "name": "중요", "createdAt": "..." }
+  ]
+}
+```
+
+### Errors
+| HTTP | code | message |
+|------|------|---------|
+| 400 | PAYLOAD_INVALID | INVALID_TAG_IDS |
+| 404 | PAYLOAD_INVALID | MATERIAL_NOT_FOUND |
+| 404 | PAYLOAD_INVALID | TAG_NOT_FOUND |
+
+---
+
+## GET /materials/:materialId/tags
+
+### 목적
+수업자료에 연결된 태그 목록을 반환한다.
+
+### Response 200
+```json
+[
+  { "id": "TAG_ID", "name": "중요", "createdAt": "..." }
+]
+```
+
+### Errors
+| HTTP | code | message |
+|------|------|---------|
+| 404 | PAYLOAD_INVALID | MATERIAL_NOT_FOUND |
+
+---
+
+## DELETE /materials/:materialId/tags/:tagId
+
+### 목적
+수업자료에서 태그를 제거한다.
+
+### Response 200
+```json
+{ "ok": true, "materialId": "MATERIAL_ID", "tagId": "TAG_ID" }
+```
+
+### Errors
+| HTTP | code | message |
+|------|------|---------|
+| 404 | PAYLOAD_INVALID | MAPPING_NOT_FOUND |

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,7 +40,7 @@ model Material {
 }
 
 model ClassMember {
-  id          String   @id
+  id          String   @id @default(cuid())
   createdAt   DateTime @default(now())
   roleInClass String   @default("student")
   userId      String
@@ -52,7 +52,7 @@ model ClassMember {
 }
 
 model MaterialSubject {
-  id         String   @id
+  id         String   @id @default(cuid())
   createdAt  DateTime @default(now())
   materialId String
   subjectId  String
@@ -64,7 +64,7 @@ model MaterialSubject {
 }
 
 model MaterialTag {
-  id         String   @id
+  id         String   @id @default(cuid())
   createdAt  DateTime @default(now())
   materialId String
   tagId      String
@@ -76,14 +76,14 @@ model MaterialTag {
 }
 
 model Subject {
-  id              String            @id
+  id              String            @id @default(cuid())
   name            String            @unique
   createdAt       DateTime          @default(now())
   MaterialSubject MaterialSubject[]
 }
 
 model Tag {
-  id          String        @id
+  id          String        @id @default(cuid())
   name        String        @unique
   createdAt   DateTime      @default(now())
   MaterialTag MaterialTag[]

--- a/src/server.js
+++ b/src/server.js
@@ -160,6 +160,14 @@ function requireAuth(req, res, next) {
   }
 }
 
+// ✅ #30: 교사 role 검증 미들웨어 (requireAuth 이후에 사용)
+function requireTeacherRole(req, res, next) {
+  if (req.role !== "teacher") {
+    return sendHttpError(res, 403, ERRORS.FORBIDDEN, "TEACHER_ONLY");
+  }
+  next();
+}
+
 // ✅ #29: class 멤버십 검증 미들웨어
 async function requireClassMember(req, res, next) {
   const classId = (req.query.classId || "").toString().trim();
@@ -298,9 +306,99 @@ app.delete("/subjects/:subjectId", async (req, res) => {
   }
 });
 
+// ✅ #30: Tag CRUD
+async function getTagOr404(tagId, res) {
+  const tag = await prisma.tag.findUnique({ where: { id: tagId } });
+  if (!tag) {
+    sendHttpError(res, 404, ERRORS.PAYLOAD_INVALID, "TAG_NOT_FOUND");
+    return null;
+  }
+  return tag;
+}
+
+app.post("/tags", requireAuth, requireTeacherRole, async (req, res) => {
+  const { name } = req.body;
+
+  if (!name || typeof name !== "string" || !name.trim()) {
+    return sendHttpError(res, 400, ERRORS.PAYLOAD_INVALID, "INVALID_TAG_NAME");
+  }
+
+  try {
+    const tag = await prisma.tag.create({ data: { name: name.trim() } });
+    return res.status(201).json(tag);
+  } catch (err) {
+    if (err?.code === "P2002") {
+      return sendHttpError(res, 409, ERRORS.PAYLOAD_INVALID, "DUPLICATE_TAG");
+    }
+    logger.error("tag create failed", { err: err?.message });
+    return sendHttpError(res, 500, ERRORS.INTERNAL_ERROR ?? "INTERNAL_ERROR", "INTERNAL_ERROR");
+  }
+});
+
+app.get("/tags", requireAuth, async (req, res) => {
+  try {
+    const tags = await prisma.tag.findMany({ orderBy: { name: "asc" } });
+    return res.json(tags);
+  } catch (err) {
+    logger.error("tags list failed", { err: err?.message });
+    return sendHttpError(res, 500, ERRORS.INTERNAL_ERROR ?? "INTERNAL_ERROR", "INTERNAL_ERROR");
+  }
+});
+
+app.get("/tags/:tagId", requireAuth, async (req, res) => {
+  const { tagId } = req.params;
+  try {
+    const tag = await prisma.tag.findUnique({ where: { id: tagId } });
+    if (!tag) return sendHttpError(res, 404, ERRORS.PAYLOAD_INVALID, "TAG_NOT_FOUND");
+    return res.json(tag);
+  } catch (err) {
+    logger.error("tag get failed", { err: err?.message });
+    return sendHttpError(res, 500, ERRORS.INTERNAL_ERROR ?? "INTERNAL_ERROR", "INTERNAL_ERROR");
+  }
+});
+
+app.put("/tags/:tagId", requireAuth, requireTeacherRole, async (req, res) => {
+  const { tagId } = req.params;
+  const { name } = req.body;
+
+  if (!name || typeof name !== "string" || !name.trim()) {
+    return sendHttpError(res, 400, ERRORS.PAYLOAD_INVALID, "INVALID_TAG_NAME");
+  }
+
+  try {
+    const tag = await getTagOr404(tagId, res);
+    if (!tag) return;
+
+    const updated = await prisma.tag.update({
+      where: { id: tagId },
+      data: { name: name.trim() },
+    });
+    return res.json(updated);
+  } catch (err) {
+    if (err?.code === "P2002") {
+      return sendHttpError(res, 409, ERRORS.PAYLOAD_INVALID, "DUPLICATE_TAG");
+    }
+    logger.error("tag update failed", { err: err?.message });
+    return sendHttpError(res, 500, ERRORS.INTERNAL_ERROR ?? "INTERNAL_ERROR", "INTERNAL_ERROR");
+  }
+});
+
+app.delete("/tags/:tagId", requireAuth, requireTeacherRole, async (req, res) => {
+  const { tagId } = req.params;
+  try {
+    const tag = await getTagOr404(tagId, res);
+    if (!tag) return;
+
+    await prisma.tag.delete({ where: { id: tagId } });
+    return res.json({ ok: true, tagId });
+  } catch (err) {
+    logger.error("tag delete failed", { err: err?.message });
+    return sendHttpError(res, 500, ERRORS.INTERNAL_ERROR ?? "INTERNAL_ERROR", "INTERNAL_ERROR");
+  }
+});
+
 /**
- * ✅ Day11: materials 검색/필터링 리스트 API (schema.prisma 기준)
- * GET /materials?classId=&subjectId=&keyword=
+ * GET /materials?classId=&subjectId=&tagId=&keyword=
  *
  * - classId: 필수
  * - subjectId: 선택 (MaterialSubject 조인 필터)
@@ -313,6 +411,7 @@ app.get("/materials", requireAuth, requireClassMember, async (req, res) => {
   try {
     const classId = (req.query.classId || "").toString().trim();
     const subjectId = (req.query.subjectId || "").toString().trim();
+    const tagId = (req.query.tagId || "").toString().trim();
     const keyword = (req.query.keyword || "").toString().trim();
 
     // 2) where 구성 (Material 기준)
@@ -326,6 +425,13 @@ app.get("/materials", requireAuth, requireClassMember, async (req, res) => {
       };
     }
 
+    // tag 필터: MaterialTag 조인 테이블을 통해 필터링
+    if (tagId) {
+      where.MaterialTag = {
+        some: { tagId },
+      };
+    }
+
     // keyword 검색: schema에 title/description이 없어서
     // 임시로 type/url에서만 검색(필요하면 Material에 title 같은 필드 추가 권장)
     if (keyword && keyword.length >= 2) {
@@ -335,7 +441,7 @@ app.get("/materials", requireAuth, requireClassMember, async (req, res) => {
       ];
     }
 
-    // 3) 조회 + subject 이름까지 포함
+    // 3) 조회 + subject/tag 이름까지 포함
     const items = await prisma.material.findMany({
       where,
       orderBy: { createdAt: "desc" },
@@ -343,6 +449,11 @@ app.get("/materials", requireAuth, requireClassMember, async (req, res) => {
         subjects: {
           include: {
             subject: { select: { id: true, name: true } },
+          },
+        },
+        MaterialTag: {
+          include: {
+            Tag: { select: { id: true, name: true } },
           },
         },
       },
@@ -359,6 +470,10 @@ app.get("/materials", requireAuth, requireClassMember, async (req, res) => {
       subjects: (m.subjects || []).map((ms) => ({
         id: ms.subject.id,
         name: ms.subject.name,
+      })),
+      tags: (m.MaterialTag || []).map((mt) => ({
+        id: mt.Tag.id,
+        name: mt.Tag.name,
       })),
     }));
 
@@ -480,6 +595,102 @@ app.delete("/materials/:materialId/subjects/:subjectId", async (req, res) => {
     return res.json({ ok: true, materialId, subjectId });
   } catch (err) {
     logger.error("material subject delete failed", { err: err?.message });
+    return sendHttpError(res, 500, ERRORS.INTERNAL_ERROR ?? "INTERNAL_ERROR", "INTERNAL_ERROR");
+  }
+});
+
+// ✅ #30: MaterialTag 엔드포인트
+app.post("/materials/:materialId/tags", requireAuth, async (req, res) => {
+  const { materialId } = req.params;
+  const { tagIds } = req.body;
+
+  if (!Array.isArray(tagIds) || tagIds.length === 0) {
+    return sendHttpError(res, 400, ERRORS.PAYLOAD_INVALID, "INVALID_TAG_IDS");
+  }
+
+  const uniqueIds = [...new Set(tagIds.map((x) => String(x).trim()).filter(Boolean))];
+  if (uniqueIds.length === 0) {
+    return sendHttpError(res, 400, ERRORS.PAYLOAD_INVALID, "INVALID_TAG_IDS");
+  }
+
+  try {
+    const material = await prisma.material.findUnique({
+      where: { id: materialId },
+      select: { id: true },
+    });
+    if (!material) {
+      return sendHttpError(res, 404, ERRORS.PAYLOAD_INVALID, "MATERIAL_NOT_FOUND");
+    }
+
+    const found = await prisma.tag.findMany({
+      where: { id: { in: uniqueIds } },
+      select: { id: true },
+    });
+    if (found.length !== uniqueIds.length) {
+      return sendHttpError(res, 404, ERRORS.PAYLOAD_INVALID, "TAG_NOT_FOUND");
+    }
+
+    await prisma.materialTag.createMany({
+      data: uniqueIds.map((tagId) => ({ materialId, tagId })),
+      skipDuplicates: true,
+    });
+
+    const mapped = await prisma.materialTag.findMany({
+      where: { materialId },
+      include: { Tag: true },
+      orderBy: { createdAt: "asc" },
+    });
+
+    return res.json({
+      materialId,
+      tags: mapped.map((m) => m.Tag),
+    });
+  } catch (err) {
+    logger.error("material tag add failed", { err: err?.message });
+    return sendHttpError(res, 500, ERRORS.INTERNAL_ERROR ?? "INTERNAL_ERROR", "INTERNAL_ERROR");
+  }
+});
+
+app.get("/materials/:materialId/tags", requireAuth, async (req, res) => {
+  const { materialId } = req.params;
+
+  try {
+    const material = await prisma.material.findUnique({
+      where: { id: materialId },
+      select: { id: true },
+    });
+    if (!material) {
+      return sendHttpError(res, 404, ERRORS.PAYLOAD_INVALID, "MATERIAL_NOT_FOUND");
+    }
+
+    const mapped = await prisma.materialTag.findMany({
+      where: { materialId },
+      include: { Tag: true },
+      orderBy: { createdAt: "asc" },
+    });
+
+    return res.json(mapped.map((m) => m.Tag));
+  } catch (err) {
+    logger.error("material tag list failed", { err: err?.message });
+    return sendHttpError(res, 500, ERRORS.INTERNAL_ERROR ?? "INTERNAL_ERROR", "INTERNAL_ERROR");
+  }
+});
+
+app.delete("/materials/:materialId/tags/:tagId", requireAuth, async (req, res) => {
+  const { materialId, tagId } = req.params;
+
+  try {
+    const deleted = await prisma.materialTag.deleteMany({
+      where: { materialId, tagId },
+    });
+
+    if (deleted.count === 0) {
+      return sendHttpError(res, 404, ERRORS.PAYLOAD_INVALID, "MAPPING_NOT_FOUND");
+    }
+
+    return res.json({ ok: true, materialId, tagId });
+  } catch (err) {
+    logger.error("material tag delete failed", { err: err?.message });
     return sendHttpError(res, 500, ERRORS.INTERNAL_ERROR ?? "INTERNAL_ERROR", "INTERNAL_ERROR");
   }
 });


### PR DESCRIPTION
#30 과목 카테고리 태그 시스템 전반을 완료하였습니다.

## 1. Subject 구조 설계
- Subject 테이블 설계 및 unique 제약 적용
- MaterialSubject 다대다 구조 구현
- ClassSubject는 데이터 정합성 측면에서 제외 (Material 중심 설계 유지)

## 2. Subject 기준 검색 API
- GET /materials?subjectId= 필터링 구현
- Subject CRUD API 완성
- Material-Subject 연결 엔드포인트 구현

## 3. Tag 시스템 확장
- Tag CRUD 구현
- MaterialTag 다대다 매핑 구현
- GET /materials에 tagId 필터 추가
- 응답에 subjects, tags 필드 포함

## 4. 권한 제어 적용 (RBAC)
- Tag 생성/수정/삭제는 교사만 가능
- Tag 조회는 로그인 사용자 가능
- MaterialTag 엔드포인트에 requireAuth 적용

## 5. DB 인덱스 및 스키마 정리
- MaterialSubject(subjectId, materialId) 인덱스 적용
- MaterialTag(tagId, materialId) 인덱스 적용
- db pull로 누락된 @default(cuid()) 복구
- prisma generate 재실행

## 6. 문서화
- docs/rest-api.md 전면 업데이트
- Tag API 및 필터 파라미터 문서 반영
- Subject vs Tag 설계 결정 사항 명시

과목(Subject) 기반 필터링과 다중 태그 확장 구조를 모두 포함하여
검색, 분류, 확장성을 갖춘 구조로 마무리하였습니다.