### PR TITLE
[Feat]: #32 - 교사 DM 및 판서의 학생 대상 실시간 전파 구조 구현 (role 기반 Socket.IO 룸 분리 적용)

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -1,1 +1,258 @@
-# develop branch notes
+# PenTalk Backend — 개발 가이드
+
+## 목차
+- [프로젝트 개요](#프로젝트-개요)
+- [기술 스택](#기술-스택)
+- [디렉토리 구조](#디렉토리-구조)
+- [환경 설정](#환경-설정)
+- [로컬 실행](#로컬-실행)
+- [아키텍처 개요](#아키텍처-개요)
+- [Redis 사용 구조](#redis-사용-구조)
+- [Socket.IO 구조](#socketio-구조)
+- [JWT 인증 흐름](#jwt-인증-흐름)
+- [개발용 스크립트](#개발용-스크립트)
+- [관련 문서](#관련-문서)
+
+---
+
+## 프로젝트 개요
+
+PenTalk 실시간 수업 플랫폼의 백엔드 서버.
+
+- REST API: 세션/수업자료/과목/태그 관리
+- Socket.IO: 실시간 판서 스트리밍, 채팅, DM
+- Redis: 세션 저장, 판서 상태(Whiteboard) 저장, Pub/Sub DM
+
+---
+
+## 기술 스택
+
+| 분류 | 기술 |
+|------|------|
+| Runtime | Node.js |
+| Framework | Express 5 |
+| 실시간 통신 | Socket.IO 4 |
+| DB ORM | Prisma 6 |
+| DB | PostgreSQL |
+| Cache / 메시지 브로커 | Redis (ioredis) |
+| 인증 | JWT (jsonwebtoken) |
+| 개발 서버 | nodemon |
+
+---
+
+## 디렉토리 구조
+
+```
+pentalk-backend/
+├── src/
+│   ├── server.js          # 앱 진입점 (Express + Socket.IO)
+│   ├── lib/
+│   │   ├── redis.js        # Redis 일반 클라이언트
+│   │   └── redisPubSub.js  # Redis Pub/Sub 전용 클라이언트 (pub/sub 분리)
+│   ├── store/
+│   │   └── sessionStore.js # 세션 CRUD (Redis 기반)
+│   ├── utils/
+│   │   ├── jwt.js          # 토큰 서명/검증
+│   │   ├── logger.js       # 로거
+│   │   └── httpError.js    # HTTP 에러 응답 헬퍼
+│   └── config/
+│       └── errors.js       # 에러 코드 상수
+├── config/
+│   ├── appConfig.js        # 서버 설정 (PORT, CORS, TTL 등)
+│   ├── socket.events.js    # Socket 이벤트명 상수
+│   ├── routes.js           # REST 라우트 경로 상수
+│   └── errors.js           # 에러 코드 상수 (공용)
+├── prisma/
+│   ├── schema.prisma       # DB 스키마
+│   ├── seed.js             # 시드 데이터
+│   └── migrations/         # 마이그레이션 파일
+├── scripts/                # 개발용 유틸 스크립트
+├── docs/                   # 문서
+└── .env                    # 환경 변수 (git 제외)
+```
+
+---
+
+## 환경 설정
+
+`.env` 파일을 프로젝트 루트에 생성한다.
+
+```env
+# 서버
+PORT=3000
+NODE_ENV=development
+CORS_ORIGIN=http://localhost:5173
+
+# JWT
+JWT_SECRET=dev-secret-change-me
+JWT_EXPIRES_IN=7d
+
+# PostgreSQL
+POSTGRES_USER=pentalk
+POSTGRES_PASSWORD=pentalk123
+POSTGRES_DB=pentalk_dev
+DATABASE_URL="postgresql://pentalk:pentalk123@localhost:5432/pentalk_dev?schema=public"
+
+# Redis
+REDIS_HOST=localhost
+REDIS_PORT=6379
+# 또는 REDIS_URL=redis://localhost:6379 (REDIS_URL 우선 적용)
+
+# 세션 TTL (초, 기본 21600 = 6시간)
+SESSION_TTL_SECONDS=21600
+
+# 클라이언트 Origin (세션 생성 시 joinUrl 생성에 사용)
+CLIENT_ORIGIN=http://localhost:5173
+```
+
+---
+
+## 로컬 실행
+
+### 1. 의존성 설치
+```bash
+npm install
+```
+
+### 2. PostgreSQL 실행 및 DB 마이그레이션
+```bash
+# DB 마이그레이션 적용
+npx prisma migrate dev
+
+# (선택) Prisma Studio로 DB 확인
+npx prisma studio
+```
+
+### 3. Redis 실행
+```bash
+# Docker 사용 시
+docker run -d -p 6379:6379 redis
+```
+
+### 4. 서버 실행
+```bash
+# 개발 (nodemon, 파일 변경 시 자동 재시작)
+npm run dev
+
+# 프로덕션
+npm start
+```
+
+서버 기본 포트: `http://localhost:3000`
+
+---
+
+## 아키텍처 개요
+
+```
+Flutter App
+    │
+    ├── REST API (HTTP)
+    │       └── Express Router → Prisma → PostgreSQL
+    │
+    └── Socket.IO (WebSocket)
+            │
+            ├── JWT 미들웨어 (연결 시 토큰 검증)
+            ├── join_room → Redis Session 조회 → Room 입장
+            ├── draw:append → Room 브로드캐스트 + Redis Whiteboard 저장
+            ├── draw:clear  → Room 브로드캐스트 + Redis Whiteboard 삭제
+            ├── sync:request → Redis Whiteboard 조회 → sync:state 응답
+            └── teacher_send_dm → Redis Pub/Sub → Room 브로드캐스트
+```
+
+---
+
+## Redis 사용 구조
+
+Redis 클라이언트는 용도별로 3개 인스턴스를 사용한다.
+
+| 인스턴스 | 파일 | 용도 |
+|----------|------|------|
+| `redis` | `src/lib/redis.js` | 세션 저장, Whiteboard 저장 |
+| `pubClient` | `src/lib/redisPubSub.js` | DM 메시지 발행(publish) |
+| `subClient` | `src/lib/redisPubSub.js` | DM 메시지 구독(subscribe) |
+
+> Pub/Sub 전용 클라이언트를 분리하는 이유: `subscribe` 상태의 Redis 연결은 일반 커맨드를 실행할 수 없기 때문.
+
+### Key 구조
+
+| Key | 타입 | TTL | 설명 |
+|-----|------|-----|------|
+| `session:{sessionId}` | String (JSON) | `SESSION_TTL_SECONDS` | 세션 메타데이터 |
+| `whiteboard:{sessionId}` | Hash | `SESSION_TTL_SECONDS` | 판서 stroke 목록 (field: sId, value: stroke JSON) |
+| `dm-channel:{sessionId}` | Pub/Sub channel | — | 교사 DM 브로드캐스트 |
+
+---
+
+## Socket.IO 구조
+
+### Room 구조
+- Room 이름: `session:{sessionId}`
+- `join_room` 이벤트 수신 시 `socket.join(roomName)` 실행
+- 브로드캐스트는 항상 `socket.to(currentRoom)` 으로 발신자 제외 전송
+
+### 인메모리 상태
+
+서버 프로세스 내에 유지되는 인메모리 상태 (재시작 시 초기화):
+
+| 변수 | 타입 | 설명 |
+|------|------|------|
+| `pendingStrokes` | `Map<sessionId, Map<sId, dsData>>` | `ds` → `de` 완성 전 임시 저장 |
+| `roomDrawTick` | `Map<roomName, number>` | 이벤트 순서 보장용 단조 증가 tick |
+
+> `pendingStrokes`: `ds` 이벤트의 색상/굵기 등 속성을 보관했다가, `de` 수신 시 병합하여 Redis에 최종 저장.
+> `roomDrawTick`: room의 모든 소켓이 disconnect되면 초기화됨.
+
+### 이벤트 목록
+→ [docs/socket-events.md](./docs/socket-events.md) 참조
+
+---
+
+## JWT 인증 흐름
+
+### Socket 연결
+1. Flutter가 `socket.handshake.auth.token`에 JWT 포함하여 연결
+2. 서버 미들웨어에서 토큰 검증 → `socket.data.userId`, `socket.data.role` 저장
+3. 검증 실패 시 연결 거부 (`UNAUTHORIZED`)
+
+### HTTP API
+1. `POST /auth/dev-login`으로 `{ userId, role }` 전달 → JWT 발급
+2. 이후 요청 헤더에 `Authorization: Bearer <token>` 포함
+3. `requireAuth` 미들웨어에서 검증 → `req.userId`, `req.role` 저장
+
+> `POST /auth/dev-login`은 개발 전용 엔드포인트. 프로덕션에서는 실제 인증 시스템으로 대체 필요.
+
+---
+
+## 개발용 스크립트
+
+```bash
+# JWT 토큰 생성 (teacher-test 유저)
+node scripts/genToken.js
+
+# DB smoke test (User/Class/Material 더미 데이터 삽입)
+node scripts/db-smoke.js
+
+# 학생 유저 삽입
+node scripts/insert-student.js
+
+# 토큰 출력
+node scripts/printToken.js
+
+# 다중 인스턴스 테스트
+node scripts/multi-instance-test.js
+
+# Whiteboard snapshot 테스트
+node scripts/snapshot-test.js
+```
+
+---
+
+## 관련 문서
+
+| 문서 | 설명 |
+|------|------|
+| [docs/socket-events.md](./docs/socket-events.md) | Socket 이벤트 명세 (판서, 채팅, DM, 상태복구) |
+| [docs/rest-api.md](./docs/rest-api.md) | REST API 명세 |
+| [docs/erd.md](./docs/erd.md) | DB ERD 및 관계/제약 설명 |
+| [docs/redis-pubsub-risk.md](./docs/redis-pubsub-risk.md) | Redis Pub/Sub 다중 서버 이슈 분석 |

--- a/README.md
+++ b/README.md
@@ -1,2 +1,87 @@
-# PenTalk_Server
-Node.js/Express / Gotenberg / Socket.IO
+# PenTalk Server
+
+실시간 판서 수업 플랫폼 **PenTalk**의 백엔드 서버.
+
+---
+
+## 주요 기능
+
+- **실시간 판서 동기화** — Socket.IO 기반 획 스트리밍 (draw:append / draw:clear)
+- **판서 상태 복구** — Redis Whiteboard 저장, 재접속 시 sync:request로 복원
+- **교사 DM** — Redis Pub/Sub 기반 다중 서버 대응 메시지 브로드캐스트
+- **세션 관리** — UUID 기반 세션 생성, Redis TTL 관리
+- **수업자료 관리** — Material / Subject / Tag CRUD REST API
+- **JWT 인증** — Socket 연결 및 HTTP API 토큰 검증
+
+---
+
+## 기술 스택
+
+| | |
+|---|---|
+| Runtime | Node.js |
+| Framework | Express 5 |
+| 실시간 통신 | Socket.IO 4 |
+| DB | PostgreSQL + Prisma 6 |
+| Cache / Pub-Sub | Redis (ioredis) |
+| 인증 | JWT |
+
+---
+
+## 빠른 시작
+
+```bash
+# 1. 의존성 설치
+npm install
+
+# 2. 환경 변수 설정
+cp .env.example .env  # 없으면 아래 참고
+
+# 3. DB 마이그레이션
+npx prisma migrate dev
+
+# 4. Redis 실행 (Docker)
+docker run -d -p 6379:6379 redis
+
+# 5. 개발 서버 실행
+npm run dev
+```
+
+서버: `http://localhost:3000`
+
+### 최소 `.env` 설정
+
+```env
+PORT=3000
+JWT_SECRET=dev-secret-change-me
+DATABASE_URL="postgresql://pentalk:pentalk123@localhost:5432/pentalk_dev?schema=public"
+REDIS_URL=redis://localhost:6379
+CORS_ORIGIN=http://localhost:5173
+```
+
+---
+
+## 문서
+
+| 문서 | 설명 |
+|------|------|
+| [DEVELOP.md](./DEVELOP.md) | 개발 환경 설정, 아키텍처, Redis 구조, 스크립트 |
+| [docs/socket-events.md](./docs/socket-events.md) | Socket 이벤트 명세 (판서, 채팅, DM, 상태복구) |
+| [docs/rest-api.md](./docs/rest-api.md) | REST API 명세 |
+| [docs/erd.md](./docs/erd.md) | DB ERD 및 관계/제약 설명 |
+
+---
+
+## 프로젝트 구조
+
+```
+src/
+├── server.js          # 앱 진입점
+├── lib/               # Redis 클라이언트
+├── store/             # 세션 저장소
+├── utils/             # JWT, 로거, HTTP 에러
+config/                # 이벤트명, 라우트, 에러 코드 상수
+prisma/                # DB 스키마 및 마이그레이션
+docs/                  # API 문서
+scripts/               # 개발용 유틸 스크립트
+```

--- a/config/socket.events.js
+++ b/config/socket.events.js
@@ -1,14 +1,15 @@
 const SOCKET_EVENTS = {
   JOIN_ROOM: 'join_room',
   JOIN_SUCCESS: 'join_success',
-  JOINED_ROOM: "joined_room",
   TEACHER_SEND_DM: "teacher_send_dm",
   RECEIVE_DM: "receive_dm",
   SEND_MESSAGE: 'send_message',
   RECEIVE_MESSAGE: 'receive_message',
   ERROR: 'server_error',
-  DRAW_EVENT: 'draw_event',
-  DRAW_SNAPSHOT: 'draw_snapshot',
+  DRAW_APPEND: 'draw:append',
+  DRAW_CLEAR: 'draw:clear',
+  SYNC_REQUEST: 'sync:request',
+  SYNC_STATE: 'sync:state',
 };
 
 module.exports = { SOCKET_EVENTS };

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -4,7 +4,7 @@
 erDiagram
     User {
         String id PK
-        String name
+        String name "nullable"
         String role
         DateTime createdAt
     }
@@ -20,7 +20,7 @@ erDiagram
         String id PK
         String userId FK
         String classId FK
-        String roleInClass
+        String roleInClass "default: student"
         DateTime createdAt
     }
 
@@ -34,7 +34,7 @@ erDiagram
 
     Subject {
         String id PK
-        String name
+        String name "unique"
         DateTime createdAt
     }
 
@@ -47,7 +47,7 @@ erDiagram
 
     Tag {
         String id PK
-        String name
+        String name "unique"
         DateTime createdAt
     }
 
@@ -60,12 +60,12 @@ erDiagram
 
     User ||--o{ Class : "teaches (teacherId)"
     User ||--o{ ClassMember : "belongs to"
-    Class ||--o{ ClassMember : "has"
-    Class ||--o{ Material : "contains"
-    Material ||--o{ MaterialSubject : "has"
-    Subject ||--o{ MaterialSubject : "tagged to"
-    Material ||--o{ MaterialTag : "has"
-    Tag ||--o{ MaterialTag : "tagged to"
+    Class ||--o{ ClassMember : "has (cascade delete)"
+    Class ||--o{ Material : "contains (cascade delete)"
+    Material ||--o{ MaterialSubject : "has (cascade delete)"
+    Subject ||--o{ MaterialSubject : "tagged to (cascade delete)"
+    Material ||--o{ MaterialTag : "has (cascade delete)"
+    Tag ||--o{ MaterialTag : "tagged to (cascade delete)"
 ```
 
 ## 관계 설명
@@ -78,6 +78,16 @@ erDiagram
 | Material ↔ Subject (MaterialSubject) | N:M | 수업자료에 여러 과목 태그 가능 |
 | Material ↔ Tag (MaterialTag) | N:M | 수업자료에 여러 태그 가능 |
 
+## 제약 조건
+
+| 테이블 | 제약 | 설명 |
+|--------|------|------|
+| ClassMember | `UNIQUE (classId, userId)` | 동일 반에 중복 멤버 방지 |
+| MaterialSubject | `UNIQUE (materialId, subjectId)` | 동일 과목 중복 연결 방지 |
+| MaterialTag | `UNIQUE (materialId, tagId)` | 동일 태그 중복 연결 방지 |
+| Subject | `UNIQUE (name)` | 과목명 중복 방지 |
+| Tag | `UNIQUE (name)` | 태그명 중복 방지 |
+
 ## 인덱스
 
 | 테이블 | 인덱스 | 목적 |
@@ -85,4 +95,13 @@ erDiagram
 | Material | `(classId, createdAt)` | 반별 최신순 조회 최적화 |
 | MaterialSubject | `(subjectId, materialId)` | 과목 기준 필터링 최적화 |
 | MaterialTag | `(tagId, materialId)` | 태그 기준 필터링 최적화 |
-| ClassMember | `UNIQUE (classId, userId)` | 중복 멤버 방지 |
+
+## Cascade Delete 규칙
+
+| 부모 삭제 시 | 연쇄 삭제 대상 |
+|-------------|---------------|
+| Class 삭제 | ClassMember, Material |
+| Material 삭제 | MaterialSubject, MaterialTag |
+| Subject 삭제 | MaterialSubject |
+| Tag 삭제 | MaterialTag |
+| User 삭제 | ClassMember |

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -22,6 +22,18 @@ Authorization: Bearer <token>
 
 ---
 
+## 목차
+
+- [POST /auth/dev-login](#post-authdev-login)
+- [POST /session/create](#post-sessioncreate)
+- [Subject API](#subject-api)
+- [GET /materials](#get-materials)
+- [Tag API](#tag-api)
+- [Material-Subject 연결 API](#material-subject-연결-api)
+- [Material-Tag 연결 API](#material-tag-연결-api)
+
+---
+
 ## POST /auth/dev-login
 
 ### 목적
@@ -34,6 +46,7 @@ Authorization: Bearer <token>
   "role": "teacher"
 }
 ```
+- `role`: `"teacher"` 또는 `"student"`만 허용
 
 ### Response 200
 ```json
@@ -61,23 +74,137 @@ Authorization: Bearer <token>
 ### Request Body
 ```json
 {
-  "classId": "c1"
+  "classId": "c1",
+  "materialId": "m1"
 }
 ```
+- `classId`: 필수. DB에 존재하는 class ID여야 한다.
+- `materialId`: 선택. 지정 시 해당 material이 존재하고 classId와 일치해야 한다.
 
 ### Response 200
 ```json
 {
   "sessionId": "uuid",
-  "joinUrlTeacher": "http://localhost:4000/?sessionId=uuid",
-  "joinUrlStudent": "http://localhost:4000/?sessionId=uuid"
+  "materialId": "m1",
+  "joinUrlTeacher": "http://localhost:5173/?sessionId=uuid&role=teacher",
+  "joinUrlStudent": "http://localhost:5173/?sessionId=uuid&role=student",
+  "ttlSeconds": 21600
 }
 ```
+- `materialId`: 세션에 연결된 material ID. 지정하지 않은 경우 `null`
+- `ttlSeconds`: 세션 유효 시간 (초). 기본값 21600 (6시간)
 
 ### Errors
+| HTTP | code | message | 설명 |
+|------|------|---------|------|
+| 400 | PAYLOAD_INVALID | MISSING_CLASS_ID | classId 누락 |
+| 404 | CLASS_NOT_FOUND | CLASS_NOT_FOUND | 존재하지 않는 class |
+| 404 | MATERIAL_NOT_FOUND | MATERIAL_NOT_FOUND | 존재하지 않는 material |
+| 400 | MATERIAL_CLASS_MISMATCH | MATERIAL_CLASS_MISMATCH | material의 classId 불일치 |
+
+---
+
+## Subject API
+
+> **인증 불필요** — 전체 엔드포인트 인증 없이 접근 가능
+
+### 설계 결정 사항
+Subject는 **과목(교육과정 단위)** 태그로, Material에 연결된다 (Class 연결 없음).
+
+---
+
+### POST /subjects
+
+#### 목적
+새 과목을 생성한다.
+
+#### Request Body
+```json
+{ "name": "수학" }
+```
+
+#### Response 201
+```json
+{ "id": "SUBJECT_ID", "name": "수학", "createdAt": "..." }
+```
+
+#### Errors
 | HTTP | code | message |
 |------|------|---------|
-| 400 | PAYLOAD_INVALID | MISSING_CLASS_ID |
+| 400 | PAYLOAD_INVALID | INVALID_SUBJECT_NAME |
+| 409 | PAYLOAD_INVALID | DUPLICATE_SUBJECT |
+| 500 | INTERNAL_ERROR | INTERNAL_ERROR |
+
+---
+
+### GET /subjects
+
+#### 목적
+전체 과목 목록을 이름 오름차순으로 반환한다.
+
+#### Response 200
+```json
+[
+  { "id": "SUBJECT_ID", "name": "수학", "createdAt": "..." }
+]
+```
+
+#### Errors
+| HTTP | code | message |
+|------|------|---------|
+| 500 | INTERNAL_ERROR | INTERNAL_ERROR |
+
+---
+
+### GET /subjects/:subjectId
+
+#### Response 200
+```json
+{ "id": "SUBJECT_ID", "name": "수학", "createdAt": "..." }
+```
+
+#### Errors
+| HTTP | code | message |
+|------|------|---------|
+| 404 | PAYLOAD_INVALID | SUBJECT_NOT_FOUND |
+| 500 | INTERNAL_ERROR | INTERNAL_ERROR |
+
+---
+
+### PUT /subjects/:subjectId
+
+#### Request Body
+```json
+{ "name": "과학" }
+```
+
+#### Response 200
+```json
+{ "id": "SUBJECT_ID", "name": "과학", "createdAt": "..." }
+```
+
+#### Errors
+| HTTP | code | message |
+|------|------|---------|
+| 400 | PAYLOAD_INVALID | INVALID_SUBJECT_NAME |
+| 404 | PAYLOAD_INVALID | SUBJECT_NOT_FOUND |
+| 409 | PAYLOAD_INVALID | DUPLICATE_SUBJECT |
+| 500 | INTERNAL_ERROR | INTERNAL_ERROR |
+
+---
+
+### DELETE /subjects/:subjectId
+
+#### Response 200
+```json
+{ "ok": true, "subjectId": "SUBJECT_ID" }
+```
+
+#### Errors
+| HTTP | code | message |
+|------|------|---------|
+| 404 | PAYLOAD_INVALID | SUBJECT_NOT_FOUND |
+| 500 | INTERNAL_ERROR | INTERNAL_ERROR |
 
 ---
 
@@ -85,7 +212,7 @@ Authorization: Bearer <token>
 
 ### 목적
 반(class) 기준으로 수업 자료(Material)를 조회한다.
-과목(subject) 및 키워드(keyword) 필터를 선택적으로 적용할 수 있다.
+과목(subject), 태그(tag), 키워드(keyword) 필터를 선택적으로 적용할 수 있다.
 
 > **인증 필요** — `Authorization: Bearer <token>` 헤더 필수
 > 토큰의 userId가 해당 class의 ClassMember에 존재해야 한다.
@@ -97,7 +224,7 @@ Authorization: Bearer <token>
 | classId | O | 반(Class) ID |
 | subjectId | X | 과목(Subject) ID |
 | tagId | X | 태그(Tag) ID |
-| keyword | X | 검색 키워드 (type, url 기준 부분 검색) |
+| keyword | X | 검색 키워드 (type, url 기준 부분 검색, 최소 2자) |
 
 ### Request 예시
 ```
@@ -113,13 +240,13 @@ GET /materials?classId=CLASS_ID&subjectId=SUBJECT_ID&tagId=TAG_ID&keyword=sample
 {
   "items": [
     {
-      "id": "cml4sj7qd0001uvupaz8w2cnd",
+      "id": "MATERIAL_ID",
       "type": "pdf",
       "url": "https://example.com/sample.pdf",
-      "classId": "cml3irfbx0002uvtjvazqiv3z",
+      "classId": "CLASS_ID",
       "createdAt": "2026-02-02T06:30:29.605Z",
       "subjects": [
-        { "id": "SUBJECT_ID", "name": "Math" }
+        { "id": "SUBJECT_ID", "name": "수학" }
       ],
       "tags": [
         { "id": "TAG_ID", "name": "중요" }
@@ -149,125 +276,213 @@ GET /materials?classId=CLASS_ID&subjectId=SUBJECT_ID&tagId=TAG_ID&keyword=sample
 - `(classId, createdAt)` 복합 인덱스로 반별 최신순 조회 최적화
 - `MaterialSubject(subjectId, materialId)` 인덱스로 과목 필터 최적화
 - `MaterialTag(tagId, materialId)` 인덱스로 태그 필터 최적화
-- EXPLAIN ANALYZE 기준 실행 시간 약 0.3ms
 
 ---
 
 ## Tag API
 
-### 설계 결정 사항
+> **POST /tags**, **PUT /tags/:tagId**, **DELETE /tags/:tagId** — 교사만 가능
+> **GET /tags**, **GET /tags/:tagId** — 인증 필요 (교사/학생 모두 가능)
 
-- Subject는 **과목(교육과정 단위)** 태그로, Material에만 연결됩니다 (Class 연결 없음).
-- Tag는 **자유 형식 다중 태그**로, Subject와 독립적으로 Material에 부여할 수 있습니다.
-- 두 태그 체계를 분리하여 확장성을 확보합니다.
+### 설계 결정 사항
+Tag는 **자유 형식 다중 태그**로, Subject와 독립적으로 Material에 부여할 수 있다.
 
 ---
 
-## POST /tags
+### POST /tags
 
-### 목적
-새 태그를 생성한다. **교사만 가능.**
+#### 목적
+새 태그를 생성한다.
 
-### Request Body
+#### Request Body
 ```json
 { "name": "중요" }
 ```
 
-### Response 201
+#### Response 201
 ```json
 { "id": "TAG_ID", "name": "중요", "createdAt": "..." }
 ```
 
-### Errors
+#### Errors
 | HTTP | code | message |
 |------|------|---------|
 | 400 | PAYLOAD_INVALID | INVALID_TAG_NAME |
+| 401 | UNAUTHORIZED | — |
+| 403 | FORBIDDEN | TEACHER_ONLY |
 | 409 | PAYLOAD_INVALID | DUPLICATE_TAG |
+| 500 | INTERNAL_ERROR | INTERNAL_ERROR |
 
 ---
 
-## GET /tags
+### GET /tags
 
-### 목적
-전체 태그 목록을 이름 오름차순으로 반환한다. **인증 필요 (교사/학생 모두 가능).**
+#### 목적
+전체 태그 목록을 이름 오름차순으로 반환한다.
 
-### Response 200
+#### Response 200
 ```json
 [
   { "id": "TAG_ID", "name": "중요", "createdAt": "..." }
 ]
 ```
 
+#### Errors
+| HTTP | code | message |
+|------|------|---------|
+| 401 | UNAUTHORIZED | — |
+| 500 | INTERNAL_ERROR | INTERNAL_ERROR |
+
 ---
 
-## GET /tags/:tagId
+### GET /tags/:tagId
 
-### Response 200
+#### Response 200
 ```json
 { "id": "TAG_ID", "name": "중요", "createdAt": "..." }
 ```
 
-### Errors
+#### Errors
 | HTTP | code | message |
 |------|------|---------|
+| 401 | UNAUTHORIZED | — |
 | 404 | PAYLOAD_INVALID | TAG_NOT_FOUND |
+| 500 | INTERNAL_ERROR | INTERNAL_ERROR |
 
 ---
 
-## GET /tags/:tagId
+### PUT /tags/:tagId
 
-> **인증 필요 (교사/학생 모두 가능)**
-
-## PUT /tags/:tagId
-
-> **교사만 가능**
-
-### Request Body
+#### Request Body
 ```json
 { "name": "매우중요" }
 ```
 
-### Response 200
+#### Response 200
 ```json
 { "id": "TAG_ID", "name": "매우중요", "createdAt": "..." }
 ```
 
-### Errors
+#### Errors
 | HTTP | code | message |
 |------|------|---------|
 | 400 | PAYLOAD_INVALID | INVALID_TAG_NAME |
+| 401 | UNAUTHORIZED | — |
+| 403 | FORBIDDEN | TEACHER_ONLY |
 | 404 | PAYLOAD_INVALID | TAG_NOT_FOUND |
 | 409 | PAYLOAD_INVALID | DUPLICATE_TAG |
+| 500 | INTERNAL_ERROR | INTERNAL_ERROR |
 
 ---
 
-## DELETE /tags/:tagId
+### DELETE /tags/:tagId
 
-> **교사만 가능**
-
-### Response 200
+#### Response 200
 ```json
 { "ok": true, "tagId": "TAG_ID" }
 ```
 
-### Errors
+#### Errors
 | HTTP | code | message |
 |------|------|---------|
+| 401 | UNAUTHORIZED | — |
+| 403 | FORBIDDEN | TEACHER_ONLY |
 | 404 | PAYLOAD_INVALID | TAG_NOT_FOUND |
+| 500 | INTERNAL_ERROR | INTERNAL_ERROR |
 
 ---
 
-## POST /materials/:materialId/tags
+## Material-Subject 연결 API
 
-### 목적
+> **인증 불필요** — 전체 엔드포인트 인증 없이 접근 가능
+
+---
+
+### POST /materials/:materialId/subjects
+
+#### 목적
+수업자료에 과목을 추가한다. 여러 개를 한 번에 추가 가능하며, 중복은 무시된다.
+
+#### Request Body
+```json
+{ "subjectIds": ["SUBJECT_ID_1", "SUBJECT_ID_2"] }
+```
+
+#### Response 200
+```json
+{
+  "materialId": "MATERIAL_ID",
+  "subjects": [
+    { "id": "SUBJECT_ID_1", "name": "수학", "createdAt": "..." }
+  ]
+}
+```
+
+#### Errors
+| HTTP | code | message |
+|------|------|---------|
+| 400 | PAYLOAD_INVALID | INVALID_SUBJECT_IDS |
+| 404 | PAYLOAD_INVALID | MATERIAL_NOT_FOUND |
+| 404 | PAYLOAD_INVALID | SUBJECT_NOT_FOUND |
+| 500 | INTERNAL_ERROR | INTERNAL_ERROR |
+
+---
+
+### GET /materials/:materialId/subjects
+
+#### 목적
+수업자료에 연결된 과목 목록을 반환한다.
+
+#### Response 200
+```json
+[
+  { "id": "SUBJECT_ID", "name": "수학", "createdAt": "..." }
+]
+```
+
+#### Errors
+| HTTP | code | message |
+|------|------|---------|
+| 404 | PAYLOAD_INVALID | MATERIAL_NOT_FOUND |
+| 500 | INTERNAL_ERROR | INTERNAL_ERROR |
+
+---
+
+### DELETE /materials/:materialId/subjects/:subjectId
+
+#### 목적
+수업자료에서 과목을 제거한다.
+
+#### Response 200
+```json
+{ "ok": true, "materialId": "MATERIAL_ID", "subjectId": "SUBJECT_ID" }
+```
+
+#### Errors
+| HTTP | code | message |
+|------|------|---------|
+| 404 | PAYLOAD_INVALID | MAPPING_NOT_FOUND |
+| 500 | INTERNAL_ERROR | INTERNAL_ERROR |
+
+---
+
+## Material-Tag 연결 API
+
+> **POST**, **GET**, **DELETE** 모두 **인증 필요** (교사/학생 모두 가능)
+
+---
+
+### POST /materials/:materialId/tags
+
+#### 목적
 수업자료에 태그를 추가한다. 여러 개를 한 번에 추가 가능하며, 중복은 무시된다.
 
-### Request Body
+#### Request Body
 ```json
 { "tagIds": ["TAG_ID_1", "TAG_ID_2"] }
 ```
 
-### Response 200
+#### Response 200
 ```json
 {
   "materialId": "MATERIAL_ID",
@@ -277,45 +492,51 @@ GET /materials?classId=CLASS_ID&subjectId=SUBJECT_ID&tagId=TAG_ID&keyword=sample
 }
 ```
 
-### Errors
+#### Errors
 | HTTP | code | message |
 |------|------|---------|
 | 400 | PAYLOAD_INVALID | INVALID_TAG_IDS |
+| 401 | UNAUTHORIZED | — |
 | 404 | PAYLOAD_INVALID | MATERIAL_NOT_FOUND |
 | 404 | PAYLOAD_INVALID | TAG_NOT_FOUND |
+| 500 | INTERNAL_ERROR | INTERNAL_ERROR |
 
 ---
 
-## GET /materials/:materialId/tags
+### GET /materials/:materialId/tags
 
-### 목적
+#### 목적
 수업자료에 연결된 태그 목록을 반환한다.
 
-### Response 200
+#### Response 200
 ```json
 [
   { "id": "TAG_ID", "name": "중요", "createdAt": "..." }
 ]
 ```
 
-### Errors
+#### Errors
 | HTTP | code | message |
 |------|------|---------|
+| 401 | UNAUTHORIZED | — |
 | 404 | PAYLOAD_INVALID | MATERIAL_NOT_FOUND |
+| 500 | INTERNAL_ERROR | INTERNAL_ERROR |
 
 ---
 
-## DELETE /materials/:materialId/tags/:tagId
+### DELETE /materials/:materialId/tags/:tagId
 
-### 목적
+#### 목적
 수업자료에서 태그를 제거한다.
 
-### Response 200
+#### Response 200
 ```json
 { "ok": true, "materialId": "MATERIAL_ID", "tagId": "TAG_ID" }
 ```
 
-### Errors
+#### Errors
 | HTTP | code | message |
 |------|------|---------|
+| 401 | UNAUTHORIZED | — |
 | 404 | PAYLOAD_INVALID | MAPPING_NOT_FOUND |
+| 500 | INTERNAL_ERROR | INTERNAL_ERROR |

--- a/docs/socket-events.md
+++ b/docs/socket-events.md
@@ -8,13 +8,14 @@
   - `socket.data.userId`
   - `socket.data.role`
 - `socket.data.classId`는 **join-room 성공 시점**에 설정된다.
+- `userId`, `role`은 JWT에서 추출하므로 이벤트 payload에 포함하지 않는다.
 
 ---
 
 ## 공통 에러 이벤트
 
 ### Event
-- `server-error`
+- `server_error`
 
 ### Payload
 ```json
@@ -34,28 +35,32 @@
 - `MESSAGE_TOO_LONG`
 - `PAYLOAD_INVALID`
 - `DM_PUBLISH_FAILED`
+- `INTERNAL_ERROR`
 
 ---
 
-## join-room
+## join_room
 
 ### Client -> Server
-- Event: `join-room`
+- Event: `join_room`
 - Payload:
 ```json
 {
-  "roomId": "sessionId"
+  "roomId": "sessionId",
+  "classId": "c1"
 }
 ```
+- `userId`, `role`은 JWT에서 자동 추출되므로 payload에 포함하지 않는다.
 
 ### Server 동작
 1. roomId 누락 시 에러
 2. 세션 존재 여부 검증
-3. 성공 시 `socket.join(roomId)`
-4. `socket.data.roomId`, `socket.data.classId` 설정
+3. classId 불일치 시 에러
+4. 성공 시 `socket.join(roomId)`
+5. `socket.data.roomId`, `socket.data.classId` 설정
 
 ### Success (Server -> Client)
-- Event: `join-success`
+- Event: `join_success`
 - Payload:
 ```json
 {
@@ -71,14 +76,15 @@
 ### Errors
 - `MISSING_ROOM_ID`
 - `SESSION_NOT_FOUND`
+- `CLASS_MISMATCH`
 
 ---
 
-## teacher-send-dm
+## teacher_send_dm
 
 ### Client -> Server
 - Auth: teacher only
-- Event: `teacher-send-dm`
+- Event: `teacher_send_dm`
 - Payload:
 ```json
 {
@@ -103,10 +109,10 @@
 
 ---
 
-## receive-dm
+## receive_dm
 
 ### Server -> Client (room broadcast, sender 제외)
-- Event: `receive-dm`
+- Event: `receive_dm`
 - Payload:
 ```json
 {
@@ -120,14 +126,14 @@
 
 ---
 
-## send-message
+## send_message
 
 ### Client -> Server
-- Event: `send-message`
+- Event: `send_message`
 - Payload:
 ```json
 {
-  "msg": "hello"
+  "message": "hello"
 }
 ```
 
@@ -144,14 +150,14 @@
 
 ---
 
-## receive-message
+## receive_message
 
 ### Server -> Client (room broadcast, sender 제외)
-- Event: `receive-message`
+- Event: `receive_message`
 - Payload:
 ```json
 {
-  "msg": "hello",
+  "message": "hello",
   "sender": {
     "userId": "u1",
     "role": "student"
@@ -162,11 +168,11 @@
 
 ---
 
-## draw_event (판서 스트리밍)
+## draw:append (판서 스트리밍)
 
 ### 개요
-실시간 판서 데이터를 room 내 클라이언트에 브로드캐스트한다.
-모든 draw 이벤트는 `draw_event` 이름으로 송수신하며, `e` 필드로 이벤트 타입을 구분한다.
+실시간 판서 데이터(획 시작/스트리밍/종료)를 room 내 클라이언트에 브로드캐스트한다.
+`e` 필드로 이벤트 타입을 구분한다.
 
 ### 이벤트 타입
 
@@ -175,12 +181,10 @@
 | `ds` | draw_start - 획 시작 | `sId`, `x`, `y`, `c`, `w` |
 | `dm` | draw_stream - 좌표 스트리밍 | `sId`, `x`, `y` |
 | `de` | draw_end - 획 종료 | `sId`, (선택) `pts` |
-| `un` | undo - 획 되돌리기 | `sId` |
-| `er` | eraser - 획 지우기 | `sId` |
 
 ### Client -> Server
 
-- Event: `draw_event`
+- Event: `draw:append`
 - 조건: join된 상태에서만 전송 가능
 
 #### ds (draw_start)
@@ -195,8 +199,8 @@
 }
 ```
 - `sId`: number - strokeId (타임스탬프 등 고유 값)
-- `x`, `y`: number - 정규화 좌표 (0~1 범위)
-- `c`: string - 색상 (hex 등)
+- `x`, `y`: number - 정규화 좌표 (0.0 ~ 1.0)
+- `c`: string - 색상 (`#RRGGBB` hex 형식, 예: `#FF0000`)
 - `w`: number - 선 굵기 (0 초과)
 
 #### dm (draw_stream)
@@ -205,41 +209,31 @@
   "e": "dm",
   "sId": 1706745600000,
   "x": 0.52,
-  "y": 0.35
+  "y": 0.35,
+  "p": 0.85
 }
 ```
 - 고빈도 이벤트. 검증 실패 시 에러 없이 drop한다.
-- `x`, `y`: 0~1 범위
+- `x`, `y`: 0.0 ~ 1.0 범위
+- `p`: (선택) number - 필압 (0.0 ~ 1.0)
 
 #### de (draw_end)
 ```json
 {
   "e": "de",
   "sId": 1706745600000,
-  "pts": [{"x":0.5,"y":0.3},{"x":0.52,"y":0.35}]
+  "pts": [
+    {"x": 0.1234, "y": 0.5678},
+    {"x": 0.1567, "y": 0.6001},
+    {"x": 0.2012, "y": 0.5823}
+  ]
 }
 ```
-- `pts`: (선택) 전체 좌표 배열. 전송 시 Array 타입이어야 한다.
-
-#### un (undo)
-```json
-{
-  "e": "un",
-  "sId": 1706745600000
-}
-```
-
-#### er (eraser)
-```json
-{
-  "e": "er",
-  "sId": 1706745600000
-}
-```
+- `pts`: (선택) 알고리즘으로 추출된 핵심 제어점 배열. 전송 시 Array 타입이어야 한다.
 
 ### Server -> Client (room broadcast, sender 제외)
 
-- Event: `draw_event`
+- Event: `draw:append`
 - 서버가 추가하는 필드:
 
 ```json
@@ -258,25 +252,89 @@
 
 ### Validation 정책
 - `ds`: 모든 필수 필드 + 좌표 범위 검증. 실패 시 `PAYLOAD_INVALID` 에러.
-- `dm`: sId, x, y 타입 + 범위 검증. 실패 시 **에러 없이 drop** (고빈도 보호).
+- `dm`: sId, x, y 타입 + 범위 검증, p는 존재 시만 검증. 실패 시 **에러 없이 drop** (고빈도 보호).
 - `de`: sId 필수, pts 전송 시 Array 타입 검증. 실패 시 `PAYLOAD_INVALID` 에러.
-- `un`, `er`: sId 필수. 실패 시 `PAYLOAD_INVALID` 에러.
 
 ### Errors
-- `NOT_JOINED` - room 미참여
-- `PAYLOAD_INVALID` - 잘못된 payload
-- `ROOM_MISMATCH` - payload.r이 현재 room과 불일치
+- `NOT_JOINED`
+- `PAYLOAD_INVALID`
+- `ROOM_MISMATCH`
 
 ---
 
-## draw_snapshot
+## draw:clear (판서 제어)
 
-### Server -> Client (join 성공 직후 1회)
+### 개요
+획 지우기(eraser) 및 실행취소(undo)를 처리한다.
+`e` 필드로 제어 타입을 구분한다.
 
-- Event: `draw_snapshot`
-- 목적: 재접속/새로고침 시 기존 판서 상태 복원
+### 이벤트 타입
 
-### Payload
+| e | 설명 |
+|---|------|
+| `un` | undo - 특정 획 되돌리기 |
+| `er` | eraser - 특정 획 지우기 |
+
+### Client -> Server
+
+- Event: `draw:clear`
+- 조건: join된 상태에서만 전송 가능
+
+#### un (undo)
+```json
+{
+  "e": "un",
+  "sId": 1706745600000
+}
+```
+
+#### er (eraser)
+```json
+{
+  "e": "er",
+  "sId": 1706745600000
+}
+```
+
+- `sId`: number - 삭제할 획의 고유 ID
+
+### Server 동작
+1. join 여부 검증
+2. `e` 타입 및 `sId` 검증
+3. room 내 브로드캐스트 (sender 제외)
+4. Redis whiteboard에서 해당 sId 삭제
+
+### Server -> Client (room broadcast, sender 제외)
+
+- Event: `draw:clear`
+```json
+{
+  "e": "un",
+  "sId": 1706745600000,
+  "senderUserId": "u1",
+  "t": 43,
+  "ts": 1706745600000
+}
+```
+
+### Errors
+- `NOT_JOINED`
+- `PAYLOAD_INVALID`
+
+---
+
+## sync:request / sync:state (판서 상태 복구)
+
+### 개요
+재접속 또는 중간 입장 시 클라이언트가 명시적으로 현재 판서 상태를 요청한다.
+
+### Client -> Server
+- Event: `sync:request`
+- Payload: 없음
+- 조건: join된 상태에서만 전송 가능
+
+### Server -> Client (요청자에게만)
+- Event: `sync:state`
 ```json
 {
   "strokes": [
@@ -287,8 +345,8 @@
       "c": "#FF0000",
       "w": 3,
       "pts": [
-        { "x": 0.1, "y": 0.2 },
-        { "x": 0.15, "y": 0.25 }
+        {"x": 0.1, "y": 0.2},
+        {"x": 0.15, "y": 0.25}
       ]
     }
   ]
@@ -296,7 +354,7 @@
 ```
 
 - `strokes`: 현재 room의 완성된 stroke 목록 (빈 배열이면 신규 입장)
-- 각 stroke는 `de` 수신 시 저장된 최종 상태 (dm 좌표 제외)
+- 각 stroke는 `de` 수신 시 저장된 최종 상태 (dm 중간 좌표 제외)
 - `un`/`er`로 삭제된 stroke는 포함되지 않음
 
 ### 저장 구조
@@ -306,5 +364,55 @@
 
 ### 클라이언트 처리 순서
 1. `join_success` 수신
-2. `draw_snapshot` 수신 → 캔버스 초기화 후 strokes 전체 렌더링
-3. 이후 `draw_event` 실시간 이벤트 적용
+2. `sync:request` 전송
+3. `sync:state` 수신 → 캔버스 초기화 후 strokes 전체 렌더링
+4. 이후 `draw:append` / `draw:clear` 실시간 이벤트 적용
+
+### Errors
+- `NOT_JOINED`
+- `INTERNAL_ERROR`
+
+---
+
+## Flutter ↔ Native MethodChannel 인터페이스
+
+### Channel Name
+`pentalk/drawing`
+
+### Flutter → Native (`sendDrawEvent`)
+Flutter에서 터치 이벤트 발생 시 Native로 소켓 전송을 요청한다.
+Native는 수신한 Map 데이터를 그대로 소켓 서버로 전송한다.
+
+- **대상 이벤트:** `draw:append` (ds/dm/de), `draw:clear` (un/er) 공통 사용
+
+```dart
+// 예시
+channel.invokeMethod('sendDrawEvent', {
+  "e": "ds",
+  "sId": 1706745600000,
+  "x": 0.5,
+  "y": 0.3,
+  "c": "#FF0000",
+  "w": 2.5,
+});
+```
+
+### Native → Flutter (`onDrawEvent`)
+소켓 서버로부터 다른 사용자의 판서 데이터를 수신했을 때 Flutter 화면에 전달한다.
+
+```dart
+// Native가 호출, Flutter에서 처리
+channel.setMethodCallHandler((call) async {
+  if (call.method == 'onDrawEvent') {
+    final data = call.arguments as Map<String, dynamic>;
+    // 캔버스 렌더링 처리
+  }
+});
+```
+
+### 좌표계 규칙
+- `x`, `y`: 디바이스 해상도 무관, **0.0 ~ 1.0 정규화 값**으로 송수신
+- Native에서 별도 좌표 변환 불필요
+
+### 색상 규칙
+- `c`: `#RRGGBB` 형식의 Hex String (예: `#FF0000`)

--- a/scripts/snapshot-test.js
+++ b/scripts/snapshot-test.js
@@ -26,9 +26,9 @@ async function run() {
     teacher.on("connect", () => teacher.emit("join_room", { roomId: sessionId }));
     teacher.on("join_success", () => {
       console.log("[TEACHER] join_success");
-      teacher.emit("draw_event", { e: "ds", sId: 99991, x: 0.1, y: 0.2, c: "#FF0000", w: 3 });
-      teacher.emit("draw_event", { e: "dm", sId: 99991, x: 0.15, y: 0.25 });
-      teacher.emit("draw_event", {
+      teacher.emit("draw:append", { e: "ds", sId: 99991, x: 0.1, y: 0.2, c: "#FF0000", w: 3 });
+      teacher.emit("draw:append", { e: "dm", sId: 99991, x: 0.15, y: 0.25 });
+      teacher.emit("draw:append", {
         e: "de", sId: 99991,
         pts: [{ x: 0.1, y: 0.2 }, { x: 0.15, y: 0.25 }, { x: 0.2, y: 0.3 }],
       });
@@ -40,14 +40,17 @@ async function run() {
   });
   teacher.disconnect();
 
-  // 3) 학생이 재접속 → draw_snapshot 수신 확인
+  // 3) 학생이 재접속 → sync:request 전송 → sync:state 수신 확인
   const student = makeSocket(studentToken);
   await new Promise((resolve, reject) => {
     const t = setTimeout(() => reject(new Error("TIMEOUT")), 4000);
     student.on("connect", () => student.emit("join_room", { roomId: sessionId }));
-    student.on("draw_snapshot", (data) => {
+    student.on("join_success", () => {
+      student.emit("sync:request");
+    });
+    student.on("sync:state", (data) => {
       clearTimeout(t);
-      console.log(`[STUDENT] draw_snapshot 수신 ✅  strokes: ${data.strokes.length}개`);
+      console.log(`[STUDENT] sync:state 수신 ✅  strokes: ${data.strokes.length}개`);
       const s = data.strokes[0];
       console.log(`  sId:${s?.sId}  c:${s?.c}  w:${s?.w}  pts:${s?.pts?.length}개`);
       resolve();

--- a/src/server.js
+++ b/src/server.js
@@ -24,7 +24,7 @@ const { signToken, verifyToken } = require('./utils/jwt');
 const { pubClient, subClient } = require("./lib/redisPubSub");
 const redis = require("./lib/redis");
 const MAX_MESSAGE_LEN = 300;
-const VALID_DRAW_TYPES = new Set(["ds", "dm", "de", "un", "er"]);
+const VALID_DRAW_APPEND_TYPES = new Set(["ds", "dm", "de"]);
 
 // ✅ #74: room별 진행 중인 stroke 임시 저장 (ds → de 완성 전까지)
 // Map<sessionId, Map<sId, {sId, x, y, c, w}>>
@@ -78,7 +78,7 @@ subClient.psubscribe("dm-channel:*", (err, count) => {
   logger.info("📡redis psubscribed", { pattern: "dm-channel:*", count });
 });
 
-// 2) 메시지 수신 → 해당 room(sessionId)로 브로드캐스트
+// 2) 메시지 수신 → 학생 룸으로만 브로드캐스트
 subClient.on("pmessage", (pattern, channel, message) => {
   try {
     // channel 예: dm-channel:abc123
@@ -87,20 +87,20 @@ subClient.on("pmessage", (pattern, channel, message) => {
 
     const payload = JSON.parse(message);
 
-    const roomName = `${APP_CONFIG.SESSION_PREFIX}${sessionId}`;
-    
+    const studentsRoom = `${APP_CONFIG.SESSION_PREFIX}${sessionId}:students`;
+
     const senderSocketId = payload?.senderSocketId;
 
     if (senderSocketId && io.sockets.sockets.has(senderSocketId)) {
-      io.to(roomName).except(senderSocketId).emit(SOCKET_EVENTS.RECEIVE_DM, payload);
+      io.to(studentsRoom).except(senderSocketId).emit(SOCKET_EVENTS.RECEIVE_DM, payload);
     } else {
-      io.to(roomName).emit(SOCKET_EVENTS.RECEIVE_DM, payload);
+      io.to(studentsRoom).emit(SOCKET_EVENTS.RECEIVE_DM, payload);
     }
 
     logger.info("📨pubsub dm broadcast", {
     channel,
     channelSessionId: sessionId,
-    roomName,
+    studentsRoom,
     fromUserId: payload?.senderUserId,
     senderSocketId: payload?.senderSocketId,
   });
@@ -863,21 +863,28 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
     }
 
 
-    const newRoom = `${APP_CONFIG.SESSION_PREFIX}${roomId}`;
+    const studentsRoom = `${APP_CONFIG.SESSION_PREFIX}${roomId}:students`;
+    const teachersRoom = `${APP_CONFIG.SESSION_PREFIX}${roomId}:teachers`;
+    const roleRoom = socket.data.role === "teacher" ? teachersRoom : studentsRoom;
 
     if (socket.currentRoom) socket.leave(socket.currentRoom);
 
-    socket.join(newRoom);
-    socket.currentRoom = newRoom;
+    socket.join(roleRoom);
+    socket.currentRoom = roleRoom;
     socket.data.roomId = roomId;
-
-    // ✅ 추가: 세션에서 classId 주입
     socket.data.classId = session.classId;
+    socket.data.studentsRoom = studentsRoom;
+    socket.data.teachersRoom = teachersRoom;
+    socket.data.roleRoom = roleRoom;
 
-    logger.info("✅join room success",{
+    logger.info("✅join room success", {
       socketId: socket.id,
-      roomId: newRoom,
-      classId: session.classId,
+      userId: socket.data.userId,
+      role: socket.data.role,
+      roomId,
+      joinedRoom: roleRoom,
+      studentsRoom,
+      teachersRoom,
     });
 
     socket.emit(SOCKET_EVENTS.JOIN_SUCCESS, {
@@ -886,15 +893,30 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
       user: { userId: socket.data.userId, role: socket.data.role }
     });
 
-    // ✅ #74: join 직후 whiteboard snapshot 전송 (재접속 복원)
+  });
+
+  // ✅ sync:request (재접속 시 명시적 판서 상태 요청 → sync:state 응답)
+  socket.on(SOCKET_EVENTS.SYNC_REQUEST, async () => {
+    if (!requireJoined(socket)) {
+      return socket.emit(SOCKET_EVENTS.ERROR, {
+        code: ERRORS.NOT_JOINED,
+        message: "NOT_JOINED",
+      });
+    }
+
+    const roomId = socket.data.roomId;
     try {
       const wbKey = `whiteboard:${roomId}`;
       const raw = await redis.hgetall(wbKey);
       const strokes = raw ? Object.values(raw).map((v) => JSON.parse(v)) : [];
-      socket.emit(SOCKET_EVENTS.DRAW_SNAPSHOT, { strokes });
-      logger.info("draw_snapshot sent", { roomId, count: strokes.length });
+      socket.emit(SOCKET_EVENTS.SYNC_STATE, { strokes });
+      logger.info("sync:state sent", { roomId, count: strokes.length });
     } catch (err) {
-      logger.error("draw_snapshot failed", { err: err?.message });
+      logger.error("sync:state failed", { err: err?.message });
+      socket.emit(SOCKET_EVENTS.ERROR, {
+        code: ERRORS.INTERNAL_ERROR,
+        message: "SYNC_FAILED",
+      });
     }
   });
 
@@ -996,18 +1018,27 @@ socket.on(SOCKET_EVENTS.SEND_MESSAGE, async (payload) => {
 
   }
 
-  // 4) 브로드캐스트 (객체)
-  socket.to(socket.currentRoom).emit(SOCKET_EVENTS.RECEIVE_MESSAGE, {
+  // 4) 브로드캐스트 — 교사/학생 양쪽 룸으로 전송 (크로스룸 채팅 유지)
+  const chatPayload = {
     message: message.trim(),
     sender: {
       userId: socket.data.userId,
       role: socket.data.role,
     },
     ts: Date.now(),
-  });
+  };
+  socket.to(socket.data.studentsRoom).to(socket.data.teachersRoom).emit(SOCKET_EVENTS.RECEIVE_MESSAGE, chatPayload);
 });
 
-socket.on(SOCKET_EVENTS.DRAW_EVENT, async (payload) => {
+// ✅ draw:append (ds: 시작, dm: 스트리밍, de: 종료)
+socket.on(SOCKET_EVENTS.DRAW_APPEND, async (payload) => {
+  if (!requireTeacher(socket)) {
+    return socket.emit(SOCKET_EVENTS.ERROR, {
+      code: ERRORS.FORBIDDEN,
+      message: "TEACHER_ONLY",
+    });
+  }
+
   if (!requireJoined(socket)) {
     return socket.emit(SOCKET_EVENTS.ERROR, {
       code: ERRORS.NOT_JOINED,
@@ -1015,10 +1046,10 @@ socket.on(SOCKET_EVENTS.DRAW_EVENT, async (payload) => {
     });
   }
 
-  if (!payload || !VALID_DRAW_TYPES.has(payload.e)) {
+  if (!payload || !VALID_DRAW_APPEND_TYPES.has(payload.e)) {
     return socket.emit(SOCKET_EVENTS.ERROR, {
       code: ERRORS.PAYLOAD_INVALID,
-      message: "INVALID_DRAW_EVENT",
+      message: "INVALID_DRAW_APPEND_EVENT",
     });
   }
 
@@ -1054,7 +1085,8 @@ socket.on(SOCKET_EVENTS.DRAW_EVENT, async (payload) => {
   if (e === "dm") {
     if (typeof payload.sId !== "number" ||
         typeof payload.x !== "number" || payload.x < 0 || payload.x > 1 ||
-        typeof payload.y !== "number" || payload.y < 0 || payload.y > 1) {
+        typeof payload.y !== "number" || payload.y < 0 || payload.y > 1 ||
+        (payload.p !== undefined && (typeof payload.p !== "number" || payload.p < 0 || payload.p > 1))) {
       return; // drop: 고빈도 이벤트이므로 에러 응답 생략
     }
   }
@@ -1066,40 +1098,35 @@ socket.on(SOCKET_EVENTS.DRAW_EVENT, async (payload) => {
         message: "INVALID_DE_PAYLOAD",
       });
     }
-    if (payload.pts !== undefined) {
-      if (!Array.isArray(payload.pts)) {
-        return socket.emit(SOCKET_EVENTS.ERROR, {
-          code: ERRORS.PAYLOAD_INVALID,
-          message: "INVALID_DE_PAYLOAD",
-        });
-      }
-    }
-  }
-
-  if (e === "un" || e === "er") {
-    if (typeof payload.sId !== "number") {
+    if (payload.pts !== undefined && !Array.isArray(payload.pts)) {
       return socket.emit(SOCKET_EVENTS.ERROR, {
         code: ERRORS.PAYLOAD_INVALID,
-        message: e === "un" ? "INVALID_UN_PAYLOAD" : "INVALID_ER_PAYLOAD",
+        message: "INVALID_DE_PAYLOAD",
       });
     }
   }
 
-  socket.to(socket.currentRoom).emit(SOCKET_EVENTS.DRAW_EVENT, {
+  socket.to(socket.data.studentsRoom).emit(SOCKET_EVENTS.DRAW_APPEND, {
     ...payload,
     senderUserId: socket.data.userId,
     senderRole: socket.data.role,
-    t: getNextTick(socket.currentRoom),
+    t: getNextTick(socket.data.studentsRoom),
     ts: Date.now(),
   });
 
-  // ✅ #74: whiteboard 저장소 갱신 (브로드캐스트 후 비동기 처리)
-  const sessionId = socket.data.roomId;
-  const wbKey = `whiteboard:${sessionId}`;
+  logger.info("📐draw:append broadcast", {
+    fromUserId: socket.data.userId,
+    roomId: socket.data.roomId,
+    studentsRoom: socket.data.studentsRoom,
+    e: payload.e,
+    sId: payload.sId,
+  });
 
-  try {
-    if (e === "de") {
-      // ds에서 보관한 색상/굵기/시작점과 병합하여 최종 stroke 저장
+  // ✅ #74: de 시 whiteboard Redis 저장
+  if (e === "de") {
+    const sessionId = socket.data.roomId;
+    const wbKey = `whiteboard:${sessionId}`;
+    try {
       const dsData = pendingStrokes.get(sessionId)?.get(payload.sId);
       const stroke = {
         sId: payload.sId,
@@ -1112,27 +1139,64 @@ socket.on(SOCKET_EVENTS.DRAW_EVENT, async (payload) => {
       await redis.hset(wbKey, String(payload.sId), JSON.stringify(stroke));
       await redis.expire(wbKey, APP_CONFIG.SESSION_TTL_SECONDS);
       pendingStrokes.get(sessionId)?.delete(payload.sId);
+    } catch (err) {
+      logger.error("whiteboard store update failed", { e, err: err?.message });
     }
-
-    if (e === "un" || e === "er") {
-      // strokeId 기준으로 저장소에서 삭제
-      await redis.hdel(wbKey, String(payload.sId));
-      pendingStrokes.get(sessionId)?.delete(payload.sId);
-    }
-  } catch (err) {
-    logger.error("whiteboard store update failed", { e, err: err?.message });
   }
 });
 
 
+  // ✅ draw:clear (un: 실행취소, er: 지우개)
+  socket.on(SOCKET_EVENTS.DRAW_CLEAR, async (payload) => {
+    if (!requireTeacher(socket)) {
+      return socket.emit(SOCKET_EVENTS.ERROR, {
+        code: ERRORS.FORBIDDEN,
+        message: "TEACHER_ONLY",
+      });
+    }
+
+    if (!requireJoined(socket)) {
+      return socket.emit(SOCKET_EVENTS.ERROR, {
+        code: ERRORS.NOT_JOINED,
+        message: "NOT_JOINED",
+      });
+    }
+
+    if (!payload || typeof payload.sId !== "number" ||
+        (payload.e !== "un" && payload.e !== "er")) {
+      return socket.emit(SOCKET_EVENTS.ERROR, {
+        code: ERRORS.PAYLOAD_INVALID,
+        message: "INVALID_DRAW_CLEAR_PAYLOAD",
+      });
+    }
+
+    socket.to(socket.data.studentsRoom).emit(SOCKET_EVENTS.DRAW_CLEAR, {
+      e: payload.e,
+      sId: payload.sId,
+      senderUserId: socket.data.userId,
+      t: getNextTick(socket.data.studentsRoom),
+      ts: Date.now(),
+    });
+
+    const sessionId = socket.data.roomId;
+    const wbKey = `whiteboard:${sessionId}`;
+    try {
+      await redis.hdel(wbKey, String(payload.sId));
+      pendingStrokes.get(sessionId)?.delete(payload.sId);
+    } catch (err) {
+      logger.error("whiteboard clear failed", { err: err?.message });
+    }
+  });
+
   // ✅ disconnect
   socket.on("disconnect", () => {
     logger.info("socket disconnected", { socketId: socket.id });
-    // room에 아무도 없으면 tick 카운터 및 pendingStrokes 정리
-    if (socket.currentRoom) {
-      const room = io.sockets.adapter.rooms.get(socket.currentRoom);
-      if (!room || room.size === 0) {
-        roomDrawTick.delete(socket.currentRoom);
+    // studentsRoom이 비면 tick 카운터 및 pendingStrokes 정리
+    const studentsRoom = socket.data?.studentsRoom;
+    if (studentsRoom) {
+      const sRoom = io.sockets.adapter.rooms.get(studentsRoom);
+      if (!sRoom || sRoom.size === 0) {
+        roomDrawTick.delete(studentsRoom);
         pendingStrokes.delete(socket.data.roomId);
       }
     }

--- a/teacherClient.js
+++ b/teacherClient.js
@@ -24,7 +24,7 @@ socket.on("join_success", (data) => {
 
   // ds: draw_start
   setTimeout(() => {
-    socket.emit("draw_event", {
+    socket.emit("draw:append", {
       e: "ds",
       sId: strokeId,
       x: 0.1,
@@ -43,7 +43,7 @@ socket.on("join_success", (data) => {
   ];
   points.forEach((pt, i) => {
     setTimeout(() => {
-      socket.emit("draw_event", {
+      socket.emit("draw:append", {
         e: "dm",
         sId: strokeId,
         x: pt.x,
@@ -55,7 +55,7 @@ socket.on("join_success", (data) => {
 
   // de: draw_end
   setTimeout(() => {
-    socket.emit("draw_event", {
+    socket.emit("draw:append", {
       e: "de",
       sId: strokeId,
       pts: [
@@ -70,14 +70,14 @@ socket.on("join_success", (data) => {
 
   // un: undo
   setTimeout(() => {
-    socket.emit("draw_event", { e: "un", sId: strokeId });
+    socket.emit("draw:clear", { e: "un", sId: strokeId });
     console.log("[teacher] un emitted, sId:", strokeId);
   }, 1000);
 
   // er: eraser
   const eraserStrokeId = Date.now() + 1;
   setTimeout(() => {
-    socket.emit("draw_event", { e: "er", sId: eraserStrokeId });
+    socket.emit("draw:clear", { e: "er", sId: eraserStrokeId });
     console.log("[teacher] er emitted, sId:", eraserStrokeId);
   }, 1200);
 
@@ -88,8 +88,12 @@ socket.on("join_success", (data) => {
   }, 1500);
 });
 
-socket.on("draw_event", (payload) => {
-  console.log("[teacher] received draw_event:", payload);
+socket.on("draw:append", (payload) => {
+  console.log("[teacher] received draw:append:", payload);
+});
+
+socket.on("draw:clear", (payload) => {
+  console.log("[teacher] received draw:clear:", payload);
 });
 
 socket.on("server_error", (e) => {

--- a/testClient.js
+++ b/testClient.js
@@ -12,9 +12,12 @@ const socket = io("http://localhost:3000", {
   auth: { token },
 });
 
-let drawEventCount = 0;
-const expectedEvents = ["ds", "dm", "dm", "dm", "de", "un", "er"];
-const receivedEvents = [];
+let appendEventCount = 0;
+let clearEventCount = 0;
+const expectedAppendEvents = ["ds", "dm", "dm", "dm", "de"];
+const expectedClearEvents = ["un", "er"];
+const receivedAppendEvents = [];
+const receivedClearEvents = [];
 const ticks = [];
 
 socket.on("connect", () => {
@@ -24,14 +27,26 @@ socket.on("connect", () => {
 
 socket.on("join_success", (data) => {
   console.log("[student] join_success:", data);
-  console.log("[student] waiting for draw events...");
+  socket.emit("sync:request");
+  console.log("[student] sync:request sent, waiting for draw events...");
 });
 
-socket.on("draw_event", (payload) => {
-  drawEventCount++;
-  receivedEvents.push(payload.e);
+socket.on("sync:state", (data) => {
+  console.log(`[student] sync:state received, strokes: ${data.strokes.length}개`);
+});
+
+socket.on("draw:append", (payload) => {
+  appendEventCount++;
+  receivedAppendEvents.push(payload.e);
   ticks.push(payload.t);
-  console.log(`[student] draw_event #${drawEventCount} (${payload.e}) t=${payload.t}:`, JSON.stringify(payload));
+  console.log(`[student] draw:append #${appendEventCount} (${payload.e}) t=${payload.t}:`, JSON.stringify(payload));
+});
+
+socket.on("draw:clear", (payload) => {
+  clearEventCount++;
+  receivedClearEvents.push(payload.e);
+  ticks.push(payload.t);
+  console.log(`[student] draw:clear #${clearEventCount} (${payload.e}) t=${payload.t}:`, JSON.stringify(payload));
 });
 
 socket.on("receive_dm", (payload) => {
@@ -48,17 +63,22 @@ socket.on("connect_error", (err) => {
 
 setTimeout(() => {
   console.log("\n--- Summary ---");
-  console.log(`received ${drawEventCount} draw events`);
-  console.log("event types:", receivedEvents.join(" -> "));
-  console.log("expected:   ", expectedEvents.join(" -> "));
-  const eventsMatch = JSON.stringify(receivedEvents) === JSON.stringify(expectedEvents);
-  console.log("events match:", eventsMatch ? "OK" : "MISMATCH");
+
+  const appendMatch = JSON.stringify(receivedAppendEvents) === JSON.stringify(expectedAppendEvents);
+  console.log(`draw:append received: ${receivedAppendEvents.join(" -> ")}`);
+  console.log(`draw:append expected: ${expectedAppendEvents.join(" -> ")}`);
+  console.log("draw:append match:", appendMatch ? "OK" : "MISMATCH");
+
+  const clearMatch = JSON.stringify(receivedClearEvents) === JSON.stringify(expectedClearEvents);
+  console.log(`draw:clear received:  ${receivedClearEvents.join(" -> ")}`);
+  console.log(`draw:clear expected:  ${expectedClearEvents.join(" -> ")}`);
+  console.log("draw:clear match:", clearMatch ? "OK" : "MISMATCH");
 
   const ticksOrdered = ticks.every((v, i) => i === 0 || v > ticks[i - 1]);
   console.log("ticks:", ticks.join(", "));
   console.log("ticks ordered:", ticksOrdered ? "OK" : "FAIL");
 
-  const allPass = eventsMatch && ticksOrdered;
+  const allPass = appendMatch && clearMatch && ticksOrdered;
   console.log("result:", allPass ? "ALL PASS" : "FAIL");
   process.exit(allPass ? 0 : 1);
 }, 10000);


### PR DESCRIPTION
## 🛠 Issue
#32 교사 DM 데이터의 학생 대상 전달 기능 구현

---

## ✅ What was implemented

### 1. Role 기반 Socket.IO 룸 구조 적용
- 기존 `session:${roomId}` 단일 룸 구조를 분리
- `session:${roomId}:students`
- `session:${roomId}:teachers`
- join_room 시 사용자 role에 따라 해당 룸에만 join하도록 변경

---

### 2. 교사 → 학생 대상 DM 전파 구조 개선
- Redis Pub/Sub DM 브로드캐스트 대상 변경
- 기존 전체 세션 룸 전파 → **students 룸 전용 전파**
- 학생에게만 실시간 메시지 전달되도록 수정

---

### 3. 판서(draw) 이벤트 권한 및 전송 대상 수정
- `draw:append`, `draw:clear` 이벤트에 `requireTeacher` 검증 추가
- 교사만 판서 전송 가능하도록 제한
- 판서 데이터는 students 룸으로만 브로드캐스트하도록 변경

---

### 4. 채팅(send_message) 크로스룸 유지
- 룸 분리 이후에도 기존 채팅 동작 유지
- students / teachers 룸 모두로 브로드캐스트하도록 수정

---

## ✅ Result
- 교사 이벤트가 학생에게만 전달되는 구조 확립
- role 기반 실시간 전파 제어 가능
- 멀티 인스턴스 환경(Redis Pub/Sub)에서도 정상 동작

---

## ⚠️ Notes
- `receive_dm` 클라이언트 수신 및 UI 처리는 프론트엔드 레포에서 구현 예정
- 대상 학생 목록 조회는 DB 조회 대신 Socket.IO 룸 멤버십 기반으로 대체

---

## ✅ Test
- 교사 → 학생 판서 실시간 전송 확인
- 학생 판서 전송 차단 확인 (TEACHER_ONLY)
- Redis Pub/Sub 환경에서 DM 전파 확인