### PR TITLE
[Feat]: #38 - Socket.IO presence 기반 사용자 접속/이탈 실시간 전파 기능 구현 및 테스트 스크립트 추가

### DIFF
--- a/config/socket.events.js
+++ b/config/socket.events.js
@@ -11,6 +11,9 @@ const SOCKET_EVENTS = {
   SYNC_REQUEST: 'sync:request',
   SYNC_STATE: 'sync:state',
   SESSION_ENDED: 'session:ended',
+  PRESENCE_JOIN: 'presence:join',
+  PRESENCE_LEAVE: 'presence:leave',
+  PRESENCE_STATE: 'presence:state',
 };
 
 module.exports = { SOCKET_EVENTS };

--- a/scripts/presence-test.js
+++ b/scripts/presence-test.js
@@ -1,0 +1,152 @@
+/**
+ * #38 presence 기능 테스트
+ *
+ * 시나리오:
+ *   1. 교사 접속 → PRESENCE_STATE로 본인 목록 수신 확인
+ *   2. 학생 접속 → 교사가 PRESENCE_JOIN 수신 확인 / 학생이 PRESENCE_STATE로 목록(교사+학생) 수신 확인
+ *   3. 학생 disconnect → 교사가 PRESENCE_LEAVE 수신 확인
+ *   4. 학생 재접속(중복 접속 시뮬레이션) → 기존 소켓 끊기고 새 소켓만 남는지 확인
+ */
+
+require("dotenv").config();
+const { io: ioClient } = require("socket.io-client");
+const { signToken } = require("../src/utils/jwt");
+
+const BASE = "http://localhost:3000";
+
+const teacherToken = signToken({ userId: "teacher-presence-test", role: "teacher" });
+const studentToken = signToken({ userId: "student-presence-test", role: "student" });
+
+async function createSession() {
+  const res = await fetch(`${BASE}/session/create`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ classId: process.env.TEST_CLASS_ID || "test-class" }),
+  });
+  const data = await res.json();
+  if (!data.sessionId) throw new Error("세션 생성 실패: " + JSON.stringify(data));
+  return data.sessionId;
+}
+
+function connectSocket(token) {
+  return ioClient(BASE, {
+    auth: { token },
+    transports: ["websocket"],
+    autoConnect: false,
+  });
+}
+
+function waitForEvent(socket, event, timeoutMs = 4000) {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(`TIMEOUT: ${event}`)), timeoutMs);
+    socket.once(event, (data) => {
+      clearTimeout(t);
+      resolve(data);
+    });
+  });
+}
+
+async function run() {
+  console.log("[TEST] presence 기능 테스트 시작\n");
+
+  const sessionId = await createSession();
+  console.log(`[SETUP] 세션 생성: ${sessionId}\n`);
+
+  // --- 시나리오 1: 교사 접속 ---
+  console.log("--- 시나리오 1: 교사 접속 ---");
+  const teacher = connectSocket(teacherToken);
+
+  const teacherStatePromise = waitForEvent(teacher, "presence:state");
+
+  await new Promise((resolve) => {
+    teacher.on("connect", () => {
+      teacher.emit("join_room", { roomId: sessionId });
+    });
+    teacher.on("join_success", resolve);
+    teacher.on("server_error", (e) => { throw new Error("[TEACHER] server_error: " + JSON.stringify(e)); });
+    teacher.connect();
+  });
+
+  const teacherState = await teacherStatePromise;
+  console.log("[TEACHER] presence:state 수신:", JSON.stringify(teacherState));
+  console.assert(teacherState.users.length === 1, "교사 접속 후 목록 1명이어야 함");
+  console.assert(teacherState.users[0].role === "teacher", "첫 번째 유저는 teacher여야 함");
+  console.log("[OK] 교사 접속 후 presence:state 검증 통과\n");
+
+  // --- 시나리오 2: 학생 접속 ---
+  console.log("--- 시나리오 2: 학생 접속 ---");
+  const student = connectSocket(studentToken);
+
+  const teacherJoinPromise = waitForEvent(teacher, "presence:join");
+  const studentStatePromise = waitForEvent(student, "presence:state");
+
+  await new Promise((resolve) => {
+    student.on("connect", () => {
+      student.emit("join_room", { roomId: sessionId });
+    });
+    student.on("join_success", resolve);
+    student.on("server_error", (e) => { throw new Error("[STUDENT] server_error: " + JSON.stringify(e)); });
+    student.connect();
+  });
+
+  const teacherJoin = await teacherJoinPromise;
+  console.log("[TEACHER] presence:join 수신:", JSON.stringify(teacherJoin));
+  console.assert(teacherJoin.userId === "student-presence-test", "join 이벤트 userId 불일치");
+  console.assert(teacherJoin.role === "student", "join 이벤트 role 불일치");
+  console.log("[OK] 교사가 학생 presence:join 수신 검증 통과");
+
+  const studentState = await studentStatePromise;
+  console.log("[STUDENT] presence:state 수신:", JSON.stringify(studentState));
+  console.assert(studentState.users.length === 2, "학생 접속 후 목록 2명이어야 함");
+  console.log("[OK] 학생 접속 후 presence:state 목록 2명 검증 통과\n");
+
+  // --- 시나리오 3: 학생 disconnect ---
+  console.log("--- 시나리오 3: 학생 disconnect ---");
+  const teacherLeavePromise = waitForEvent(teacher, "presence:leave");
+  student.disconnect();
+
+  const teacherLeave = await teacherLeavePromise;
+  console.log("[TEACHER] presence:leave 수신:", JSON.stringify(teacherLeave));
+  console.assert(teacherLeave.userId === "student-presence-test", "leave 이벤트 userId 불일치");
+  console.assert(teacherLeave.role === "student", "leave 이벤트 role 불일치");
+  console.log("[OK] 학생 disconnect 후 교사 presence:leave 검증 통과\n");
+
+  // --- 시나리오 4: 학생 중복 접속 ---
+  console.log("--- 시나리오 4: 학생 중복 접속 (old 소켓 자동 끊기) ---");
+  const student2 = connectSocket(studentToken);
+  const student3 = connectSocket(studentToken);
+
+  // student2 먼저 join
+  await new Promise((resolve) => {
+    student2.on("connect", () => student2.emit("join_room", { roomId: sessionId }));
+    student2.on("join_success", resolve);
+    student2.connect();
+  });
+  console.log("[STUDENT2] join 완료");
+
+  // student3 join → student2는 서버에서 끊겨야 함
+  const student2DisconnectedPromise = new Promise((resolve) => {
+    student2.on("disconnect", resolve);
+  });
+
+  await new Promise((resolve) => {
+    student3.on("connect", () => student3.emit("join_room", { roomId: sessionId }));
+    student3.on("join_success", resolve);
+    student3.connect();
+  });
+  console.log("[STUDENT3] join 완료 (중복 접속)");
+
+  await student2DisconnectedPromise;
+  console.log("[STUDENT2] 서버에 의해 disconnect됨 확인");
+  console.log("[OK] 중복 접속 시 old 소켓 자동 끊기 검증 통과\n");
+
+  teacher.disconnect();
+  student3.disconnect();
+
+  console.log("=== [RESULT] 모든 시나리오 통과 ✅ ===");
+}
+
+run().catch((err) => {
+  console.error("\n[RESULT] 테스트 실패:", err.message);
+  process.exit(1);
+});

--- a/src/server.js
+++ b/src/server.js
@@ -35,6 +35,38 @@ const VALID_DRAW_APPEND_TYPES = new Set(["ds", "dm", "de"]);
 // Map<sessionId, Map<sId, {sId, x, y, c, w}>>
 const pendingStrokes = new Map();
 
+// ✅ #38: presence 자료구조 (sessionId -> Map(userKey -> socketId))
+const presenceBySession = new Map();
+
+function userKeyOf(socket) {
+  return `${socket.data.role}:${socket.data.userId}`;
+}
+
+function getSessionPresence(roomId) {
+  let m = presenceBySession.get(roomId);
+  if (!m) {
+    m = new Map();
+    presenceBySession.set(roomId, m);
+  }
+  return m;
+}
+
+function buildPresenceList(roomId) {
+  const m = presenceBySession.get(roomId);
+  if (!m) return [];
+  return Array.from(m.keys()).map((k) => {
+    const [role, userId] = k.split(":");
+    return { userId, role };
+  });
+}
+
+function getRoleRooms(roomId) {
+  return {
+    studentsRoom: `${APP_CONFIG.SESSION_PREFIX}${roomId}:students`,
+    teachersRoom: `${APP_CONFIG.SESSION_PREFIX}${roomId}:teachers`,
+  };
+}
+
 
 
 function isValidMessage(msg) {
@@ -1078,6 +1110,35 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
       user: { userId: socket.data.userId, role: socket.data.role }
     });
 
+    // ✅ #38: presence 입장 처리
+    const sessionPresence = getSessionPresence(roomId);
+    const meKey = userKeyOf(socket);
+
+    // 중복 접속 처리: 같은 userId+role이 이미 접속 중이면 기존 소켓 끊기
+    const existingSocketId = sessionPresence.get(meKey);
+    if (existingSocketId && existingSocketId !== socket.id) {
+      const oldSocket = io.sockets.sockets.get(existingSocketId);
+      if (oldSocket) oldSocket.disconnect(true);
+      sessionPresence.delete(meKey);
+    }
+
+    // 현재 소켓 등록
+    sessionPresence.set(meKey, socket.id);
+
+    // 본인에게 현재 접속자 목록 전달
+    socket.emit(SOCKET_EVENTS.PRESENCE_STATE, {
+      roomId,
+      users: buildPresenceList(roomId),
+    });
+
+    // 같은 세션의 학생/교사 룸 전체에 입장 브로드캐스트 (본인 제외)
+    const { studentsRoom: sRoom, teachersRoom: tRoom } = getRoleRooms(roomId);
+    socket.to(sRoom).to(tRoom).emit(SOCKET_EVENTS.PRESENCE_JOIN, {
+      roomId,
+      userId: socket.data.userId,
+      role: socket.data.role,
+    });
+
   });
 
   // ✅ sync:request (재접속 시 명시적 판서 상태 요청 → sync:state 응답)
@@ -1412,6 +1473,32 @@ socket.on(SOCKET_EVENTS.DRAW_APPEND, async (payload) => {
       pendingStrokes.get(sessionId)?.delete(payload.sId);
     } catch (err) {
       logger.error("whiteboard clear failed", { err: err?.message });
+    }
+  });
+
+  // ✅ #38: disconnecting - 룸이 비워지기 전에 presence:leave 브로드캐스트
+  socket.on("disconnecting", (reason) => {
+    const roomId = socket.data.roomId;
+    if (!roomId) return;
+
+    const sessionPresence = presenceBySession.get(roomId);
+    if (!sessionPresence) return;
+
+    const meKey = userKeyOf(socket);
+    const existingSocketId = sessionPresence.get(meKey);
+
+    // 현재 끊기는 소켓이 등록된 소켓일 때만 제거 (중복 접속 race 방어)
+    if (existingSocketId === socket.id) {
+      sessionPresence.delete(meKey);
+      if (sessionPresence.size === 0) presenceBySession.delete(roomId);
+
+      const { studentsRoom: sRoom, teachersRoom: tRoom } = getRoleRooms(roomId);
+      socket.to(sRoom).to(tRoom).emit(SOCKET_EVENTS.PRESENCE_LEAVE, {
+        roomId,
+        userId: socket.data.userId,
+        role: socket.data.role,
+        reason,
+      });
     }
   });
 


### PR DESCRIPTION
## 🛠 Issue

#38 Socket.IO presence 기능 기반 접속/이탈 실시간 전송

## ✨ 구현 내용

Socket.IO의 `connection` 및 `disconnecting` 이벤트를 활용하여
세션 내 사용자들의 접속/이탈 상태를 실시간으로 감지하고, 같은 세션에 속한 사용자들에게 전파하는 presence 기능을 구현했습니다.

* `presenceBySession` Map을 사용하여 세션별 접속 사용자 상태 관리
* 동일 `userId + role` 중복 접속 시 기존 socket disconnect 처리
* JOIN 시:

  * `PRESENCE_STATE` → 접속한 사용자에게 현재 접속자 목록 전달
  * `PRESENCE_JOIN` → 같은 세션 사용자들에게 입장 이벤트 브로드캐스트
* DISCONNECT 시:

  * `disconnecting` 이벤트에서 `PRESENCE_LEAVE` 브로드캐스트
  * race condition 방어 로직 적용
* 세션 룸(`session:{roomId}:students`, `session:{roomId}:teachers`) 기준으로 이벤트 전파

## 📁 변경 파일

* `config/socket.events.js`

  * `PRESENCE_JOIN`, `PRESENCE_LEAVE`, `PRESENCE_STATE` 이벤트 상수 추가

* `src/server.js`

  * presence 상태 관리 Map 및 helper 함수 추가
  * JOIN 시 presence 등록 및 브로드캐스트 로직 구현
  * `disconnecting` 이벤트에서 leave 브로드캐스트 처리

* `scripts/presence-test.js`

  * presence 기능 동작 검증용 테스트 스크립트 추가

## 🧪 테스트

presence 테스트 스크립트를 통해 아래 시나리오 검증

1. 교사 접속 → `PRESENCE_STATE` 수신 확인
2. 학생 접속 → 교사가 `PRESENCE_JOIN` 수신 확인
3. 학생 disconnect → 교사가 `PRESENCE_LEAVE` 수신 확인
4. 동일 계정 재접속 → 기존 socket disconnect 확인
