### PR TITLE
[Feat]: #42 - 종료된 세션 판서 데이터 Read-only 조회 및 수정 차단 구현

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -3,6 +3,7 @@
 const ROUTES = {
   SESSION_CREATE: '/session/create',
   SESSION_END: '/sessions/:sessionId/end',
+  WHITEBOARD_GET: '/sessions/:sessionId/whiteboard',
 };
 
 module.exports = { ROUTES };

--- a/src/server.js
+++ b/src/server.js
@@ -38,6 +38,9 @@ const pendingStrokes = new Map();
 // ✅ #38: presence 자료구조 (sessionId -> Map(userKey -> socketId))
 const presenceBySession = new Map();
 
+// ✅ #42: 종료된 세션 Set (draw 이벤트 차단용)
+const archivedSessions = new Set();
+
 function userKeyOf(socket) {
   return `${socket.data.role}:${socket.data.userId}`;
 }
@@ -885,6 +888,8 @@ app.post(ROUTES.SESSION_END, requireAuth, requireTeacherRole, async (req, res) =
     // 9. Socket session:ended 브로드캐스트
     const studentsRoom = `${APP_CONFIG.SESSION_PREFIX}${sessionId}:students`;
     const teachersRoom = `${APP_CONFIG.SESSION_PREFIX}${sessionId}:teachers`;
+    archivedSessions.add(sessionId);
+
     io.to(studentsRoom).to(teachersRoom).emit(SOCKET_EVENTS.SESSION_ENDED, {
       sessionId,
       endedAt: closedAt.getTime(),
@@ -940,6 +945,49 @@ app.post(ROUTES.SESSION_END, requireAuth, requireTeacherRole, async (req, res) =
       });
     } catch (_) { /* DB 기록 실패는 무시 */ }
     return sendHttpError(res, 500, ERRORS.INTERNAL_ERROR, "SESSION_END_FAILED");
+  }
+});
+
+// ✅ #42: 판서 데이터 조회 API (ARCHIVED → 파일, ACTIVE → Redis)
+app.get(ROUTES.WHITEBOARD_GET, requireAuth, async (req, res) => {
+  const { sessionId } = req.params;
+
+  try {
+    // ARCHIVED 여부 DB 확인
+    const dbSession = await prisma.session.findUnique({
+      where: { id: sessionId },
+      select: { status: true, drawingPath: true },
+    });
+
+    if (dbSession?.status === 'ARCHIVED') {
+      if (!dbSession.drawingPath) {
+        return sendHttpError(res, 404, ERRORS.SESSION_NOT_FOUND, "DRAWING_NOT_FOUND");
+      }
+      const raw = await fs.promises.readFile(dbSession.drawingPath, 'utf8');
+      const data = JSON.parse(raw);
+      return res.json({ sessionId, readOnly: true, strokes: data.strokes ?? [] });
+    }
+
+    // ACTIVE: Redis에서 조회
+    const session = await sessionStore.get(sessionId);
+    if (!session) {
+      return sendHttpError(res, 404, ERRORS.SESSION_NOT_FOUND, "SESSION_NOT_FOUND");
+    }
+
+    const wbKey = `whiteboard:${sessionId}`;
+    const raw = await redis.get(wbKey);
+    let strokes = [];
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw);
+        strokes = Array.isArray(parsed?.strokes) ? parsed.strokes : [];
+      } catch (_) {}
+    }
+
+    return res.json({ sessionId, readOnly: false, strokes });
+  } catch (err) {
+    logger.error("whiteboard get failed", { sessionId, err: err?.message });
+    return sendHttpError(res, 500, ERRORS.INTERNAL_ERROR, "WHITEBOARD_GET_FAILED");
   }
 });
 
@@ -1381,6 +1429,12 @@ socket.on(SOCKET_EVENTS.DRAW_APPEND, async (payload) => {
     });
   }
 
+  // ✅ #42: 종료된 세션 판서 차단
+  if (archivedSessions.has(socket.data.roomId)) {
+    logger.warn("draw:append blocked: session archived", { sessionId: socket.data.roomId, userId: socket.data.userId });
+    return socket.emit(SOCKET_EVENTS.ERROR, { code: ERRORS.SESSION_ENDED, message: "종료된 세션에서는 판서가 불가합니다" });
+  }
+
   const roomId = payload.r || socket.data.roomId;
   if (roomId !== socket.data.roomId) {
     return socket.emit(SOCKET_EVENTS.ERROR, {
@@ -1511,6 +1565,12 @@ socket.on(SOCKET_EVENTS.DRAW_APPEND, async (payload) => {
         code: ERRORS.PAYLOAD_INVALID,
         message: "INVALID_DRAW_CLEAR_PAYLOAD",
       });
+    }
+
+    // ✅ #42: 종료된 세션 판서 차단
+    if (archivedSessions.has(socket.data.roomId)) {
+      logger.warn("draw:clear blocked: session archived", { sessionId: socket.data.roomId, userId: socket.data.userId });
+      return socket.emit(SOCKET_EVENTS.ERROR, { code: ERRORS.SESSION_ENDED, message: "종료된 세션에서는 판서가 불가합니다" });
     }
 
     socket.to(socket.data.studentsRoom).emit(SOCKET_EVENTS.DRAW_CLEAR, {


### PR DESCRIPTION
## 📌 개요

종료된 세션의 판서 데이터를 수정할 수 없도록 하고, 이전 수업의 판서 내용을 안전하게 열람할 수 있도록 **Read-only 조회 기능**을 추가했습니다.

세션 상태(`ACTIVE`, `ARCHIVED`)에 따라 판서 데이터를 조회하는 방식이 달라지며, 종료된 세션에서는 판서 수정 이벤트를 차단하여 데이터 무결성을 보장합니다.

---

## 🛠 주요 구현 내용

### 1. 판서 조회 API 추가

* `GET /sessions/:sessionId/whiteboard`
* 세션 상태에 따라 데이터 조회 방식 분기

**ARCHIVED 세션**

* DB에서 `drawingPath` 조회
* 저장된 판서 JSON 파일을 읽어 응답
* `readOnly: true` 반환

**ACTIVE 세션**

* Redis (`whiteboard:{sessionId}`)에서 판서 데이터 조회
* `readOnly: false` 반환

---

### 2. 종료된 세션 판서 수정 차단

다음 판서 수정 이벤트에서 종료 세션 여부를 확인하여 차단 처리

* `draw:append`
* `draw:clear`

종료된 세션에서 판서 시도 시

* 이벤트 차단
* 클라이언트에 `SESSION_ENDED` 오류 반환
* 서버 로그 기록

---

### 3. Read-only 상태 전달

조회 API 응답에 `readOnly` 플래그를 포함하여
클라이언트에서 판서 편집 UI를 비활성화할 수 있도록 지원

예시 응답:

```
{
  "sessionId": "...",
  "readOnly": true,
  "strokes": [...]
}
```

---

### 4. 비정상 수정 시도 로그 기록

종료된 세션에서 판서 이벤트가 발생할 경우

```
logger.warn("draw blocked: session archived", { sessionId, userId })
```

형태로 로그를 기록하여 추후 분석이 가능하도록 처리했습니다.

---

## 📈 기대 효과

* 종료된 수업 판서 데이터의 무결성 보장
* 이전 수업 자료를 안전하게 조회 가능
* 판서 수정 이벤트에 대한 서버 측 안전 장치 강화
