### PR TITLE
[Feat]: #85 - Docker Compose 기반 로컬 개발 환경 구성

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+.env
+storage
+*.log
+tests
+docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY prisma ./prisma
+RUN npx prisma generate
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["sh", "-c", "npx prisma migrate deploy && node src/server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,5 +20,23 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
+  app:
+    build: .
+    container_name: pentalk-app
+    restart: always
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env
+    environment:
+      - REDIS_HOST=redis
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?schema=public
+    volumes:
+      - whiteboard_data:/app/storage/whiteboards
+    depends_on:
+      - redis
+      - postgres
+
 volumes:
   postgres_data:
+  whiteboard_data:


### PR DESCRIPTION
Docker Compose를 사용하여 Redis, PostgreSQL, Node.js 서버를
한 번에 실행할 수 있는 로컬 개발 환경을 구성했습니다.

프론트엔드 개발자가 서버 실행을 요청하지 않아도
docker-compose up 명령으로 백엔드 환경을 직접 실행할 수 있도록 개선했습니다.

주요 변경 사항
- Node.js 서버 실행을 위한 Dockerfile 추가
- .dockerignore 설정
- docker-compose.yml에 app 서비스 추가
- Redis / PostgreSQL / App 컨테이너 네트워크 연결