### PR TITLE
[Feat]: #45 - 판서 펜 타입(color, width) 관리 기능 구현 및 안정성 개선

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -31,6 +31,24 @@ const redis = require("./lib/redis");
 const MAX_MESSAGE_LEN = 300;
 const VALID_DRAW_APPEND_TYPES = new Set(["ds", "dm", "de"]);
 
+// ✅ #45: 펜 스타일 설정 상수
+const PEN_CONFIG = {
+  DEFAULT_COLOR: "#000000",
+  DEFAULT_WIDTH: 2,
+  MAX_WIDTH: 50, // 프론트 UI 펜 굵기 허용 범위 상한 (픽셀 기준)
+  HEX_RE: /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/,
+};
+
+// ✅ #45: 구형 stroke 데이터(c/w 없음) 정규화
+function normalizeStroke(s) {
+  if (!s) return s;
+  return {
+    ...s,
+    c: (typeof s.c === "string" && PEN_CONFIG.HEX_RE.test(s.c)) ? s.c : PEN_CONFIG.DEFAULT_COLOR,
+    w: (typeof s.w === "number" && s.w > 0 && s.w <= PEN_CONFIG.MAX_WIDTH) ? s.w : PEN_CONFIG.DEFAULT_WIDTH,
+  };
+}
+
 // ✅ #74: room별 진행 중인 stroke 임시 저장 (ds → de 완성 전까지)
 // Map<sessionId, Map<sId, {sId, x, y, c, w}>>
 const pendingStrokes = new Map();
@@ -1001,7 +1019,7 @@ app.get(ROUTES.WHITEBOARD_GET, requireAuth, async (req, res) => {
       }
       const raw = await fs.promises.readFile(dbSession.drawingPath, 'utf8');
       const data = JSON.parse(raw);
-      return res.json({ sessionId, readOnly: true, strokes: data.strokes ?? [] });
+      return res.json({ sessionId, readOnly: true, strokes: (data.strokes ?? []).map(normalizeStroke) });
     }
 
     // ACTIVE: Redis에서 조회
@@ -1020,7 +1038,7 @@ app.get(ROUTES.WHITEBOARD_GET, requireAuth, async (req, res) => {
       } catch (_) {}
     }
 
-    return res.json({ sessionId, readOnly: false, strokes });
+    return res.json({ sessionId, readOnly: false, strokes: strokes.map(normalizeStroke) });
   } catch (err) {
     logger.error("whiteboard get failed", { sessionId, err: err?.message });
     return sendHttpError(res, 500, ERRORS.INTERNAL_ERROR, "WHITEBOARD_GET_FAILED");
@@ -1362,7 +1380,7 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
         : strokes;
 
       socket.emit(SOCKET_EVENTS.SYNC_STATE, {
-        strokes: payloadStrokes,
+        strokes: payloadStrokes.map(normalizeStroke),
         mode,
         serverTick: meta.serverTick,
       });
@@ -1539,8 +1557,8 @@ socket.on(SOCKET_EVENTS.DRAW_APPEND, async (payload) => {
     if (typeof payload.sId !== "number" ||
         typeof payload.x !== "number" || payload.x < 0 || payload.x > 1 ||
         typeof payload.y !== "number" || payload.y < 0 || payload.y > 1 ||
-        typeof payload.c !== "string" || !payload.c ||
-        typeof payload.w !== "number" || payload.w <= 0) {
+        typeof payload.c !== "string" || !PEN_CONFIG.HEX_RE.test(payload.c) ||
+        typeof payload.w !== "number" || payload.w <= 0 || payload.w > PEN_CONFIG.MAX_WIDTH) {
       return socket.emit(SOCKET_EVENTS.ERROR, {
         code: ERRORS.PAYLOAD_INVALID,
         message: "INVALID_DS_PAYLOAD",
@@ -1604,8 +1622,14 @@ socket.on(SOCKET_EVENTS.DRAW_APPEND, async (payload) => {
     const tick = await getNextTick(sessionId);
     const ts = Date.now();
 
+    // ✅ #45: de 브로드캐스트 전에 dsData를 먼저 조회하여 c/w 보완
+    const sessionMap = pendingStrokes.get(sessionId);
+    const dsData = sessionMap?.get(payload.sId);
+
     socket.to(socket.data.studentsRoom).emit(SOCKET_EVENTS.DRAW_APPEND, {
       ...payload,
+      c: dsData?.c ?? PEN_CONFIG.DEFAULT_COLOR,
+      w: dsData?.w ?? PEN_CONFIG.DEFAULT_WIDTH,
       senderUserId: socket.data.userId,
       senderRole: socket.data.role,
       t: tick,
@@ -1621,7 +1645,6 @@ socket.on(SOCKET_EVENTS.DRAW_APPEND, async (payload) => {
     });
 
     try {
-      const dsData = pendingStrokes.get(sessionId)?.get(payload.sId);
       if (!dsData) {
         logger.warn("draw:append 'de' received without 'ds'", {
           sessionId,
@@ -1633,8 +1656,8 @@ socket.on(SOCKET_EVENTS.DRAW_APPEND, async (payload) => {
         sId: payload.sId,
         x: dsData?.x ?? 0,
         y: dsData?.y ?? 0,
-        c: dsData?.c ?? "#000000",
-        w: dsData?.w ?? 2,
+        c: dsData?.c ?? PEN_CONFIG.DEFAULT_COLOR,
+        w: dsData?.w ?? PEN_CONFIG.DEFAULT_WIDTH,
         pts: Array.isArray(payload.pts) ? payload.pts : [],
         t: tick,
       };
@@ -1819,6 +1842,12 @@ socket.on(SOCKET_EVENTS.DRAW_APPEND, async (payload) => {
         pendingStrokes.delete(socket.data.roomId);
         tickInitPromise.delete(socket.data.roomId); // 혹시 남은 init promise 정리
       }
+    }
+
+    // ✅ #45: 교사 disconnect 시 해당 소켓의 미완성 stroke 정리 (메모리 누수 방지)
+    // ds → de 없이 끊기면 pendingStrokes에 고아 항목이 남을 수 있음
+    if (socket.data.role === "teacher" && socket.data.roomId) {
+      pendingStrokes.delete(socket.data.roomId);
     }
   });
 });

--- a/tests/45-pen-style.test.js
+++ b/tests/45-pen-style.test.js
@@ -1,0 +1,261 @@
+/**
+ * #45 펜 타입(color, width) 통합 테스트
+ *
+ * 실행: npx jest tests/45-pen-style.test.js --runInBand --forceExit
+ *
+ * 전제: Redis 실행 중 (DB 불필요 - lastSession 캐시로 DB 조회 우회)
+ */
+require('dotenv').config();
+
+const { io: ioc } = require('socket.io-client');
+const jwt = require('jsonwebtoken');
+const redis = require('../src/lib/redis');
+const { app, server, io } = require('../src/server');
+
+const PORT = 3097;
+const BASE_URL = `http://localhost:${PORT}`;
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-change-me';
+const SESSION_ID = `test-session-45-${Date.now()}`;
+const CLASS_ID = 'test-class-45';
+let tokenCounter = 0;
+
+// userId와 JWT를 동일한 tokenCounter 기준으로 생성 (불일치 방지)
+function makeAuth(role) {
+  tokenCounter++;
+  const userId = `${role}-${tokenCounter}`;
+  const token = jwt.sign({ userId, role }, JWT_SECRET, { expiresIn: '1h' });
+  return { userId, token };
+}
+
+function connect(token) {
+  return ioc(BASE_URL, {
+    auth: { token },
+    transports: ['websocket'],
+    forceNew: true,
+  });
+}
+
+function waitFor(socket, event, ms = 3000) {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(`timeout: ${event}`)), ms);
+    socket.once(event, (d) => { clearTimeout(t); resolve(d); });
+  });
+}
+
+function waitForDrawAppend(socket, eType, ms = 3000) {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(`timeout: draw:append e=${eType}`)), ms);
+    function handler(data) {
+      if (data.e === eType) { clearTimeout(t); socket.off('draw:append', handler); resolve(data); }
+    }
+    socket.on('draw:append', handler);
+  });
+}
+
+async function cleanupRedis() {
+  await redis.del(
+    `session:${SESSION_ID}`,
+    `whiteboard:${SESSION_ID}`,
+    `whiteboardMeta:${SESSION_ID}`,
+    `lock:whiteboard:${SESSION_ID}`,
+  );
+}
+
+async function joinAs(role) {
+  const { userId, token } = makeAuth(role);
+  const socket = connect(token);
+  await waitFor(socket, 'connect');
+  await redis.setex(
+    `user:${userId}:lastSession`, 3600,
+    JSON.stringify({ sessionId: SESSION_ID, classId: CLASS_ID, materialId: null }),
+  );
+  socket.emit('join_room', { roomId: SESSION_ID, classId: CLASS_ID });
+  await waitFor(socket, 'join_success');
+  return socket;
+}
+
+beforeAll((done) => {
+  server.listen(PORT, done);
+});
+
+afterAll(async () => {
+  await cleanupRedis();
+  io.close();
+  await new Promise((r) => server.close(r));
+  // redis.quit()는 공용 클라이언트이므로 여기서 종료하지 않음
+  // (다른 테스트 파일과 병렬 실행 시 영향 방지)
+}, 20000);
+
+beforeEach(async () => {
+  await cleanupRedis();
+  await redis.setex(
+    `session:${SESSION_ID}`, 3600,
+    JSON.stringify({ id: SESSION_ID, classId: CLASS_ID, materialId: null, createdAt: Date.now() }),
+  );
+});
+
+// ─── 시나리오 1. ds 브로드캐스트에 c/w 포함 ───────────────────────────────
+describe('시나리오 1. ds 브로드캐스트', () => {
+  test('학생이 수신하는 ds 이벤트에 c, w가 포함된다', async () => {
+    const teacher = await joinAs('teacher');
+    const student = await joinAs('student');
+
+    const dsPromise = waitForDrawAppend(student, 'ds');
+    teacher.emit('draw:append', { e: 'ds', sId: 1, r: SESSION_ID, x: 0.1, y: 0.1, c: '#ff0000', w: 5 });
+    const ds = await dsPromise;
+
+    expect(ds.c).toBe('#ff0000');
+    expect(ds.w).toBe(5);
+
+    teacher.disconnect();
+    student.disconnect();
+  });
+});
+
+// ─── 시나리오 2. de 브로드캐스트에 c/w 포함 ───────────────────────────────
+describe('시나리오 2. de 브로드캐스트', () => {
+  test('학생이 수신하는 de 이벤트에 ds의 c, w가 포함된다', async () => {
+    const teacher = await joinAs('teacher');
+    const student = await joinAs('student');
+
+    teacher.emit('draw:append', { e: 'ds', sId: 2, r: SESSION_ID, x: 0.1, y: 0.1, c: '#00ff00', w: 10 });
+    teacher.emit('draw:append', { e: 'dm', sId: 2, r: SESSION_ID, x: 0.2, y: 0.2 });
+
+    const dePromise = waitForDrawAppend(student, 'de');
+    teacher.emit('draw:append', { e: 'de', sId: 2, r: SESSION_ID, pts: [[0.1, 0.1]] });
+    const de = await dePromise;
+
+    expect(de.c).toBe('#00ff00');
+    expect(de.w).toBe(10);
+
+    teacher.disconnect();
+    student.disconnect();
+  });
+
+  test('ds 없이 de만 온 경우 기본값(#000000, 2)으로 브로드캐스트된다', async () => {
+    const teacher = await joinAs('teacher');
+    const student = await joinAs('student');
+
+    const dePromise = waitForDrawAppend(student, 'de');
+    teacher.emit('draw:append', { e: 'de', sId: 98, r: SESSION_ID, pts: [] });
+    const de = await dePromise;
+
+    expect(de.c).toBe('#000000');
+    expect(de.w).toBe(2);
+
+    teacher.disconnect();
+    student.disconnect();
+  });
+});
+
+// ─── 시나리오 3. Redis 저장 포맷에 c/w 포함 ───────────────────────────────
+describe('시나리오 3. Redis 저장', () => {
+  test('de 완료 후 Redis stroke에 c, w가 저장된다', async () => {
+    const teacher = await joinAs('teacher');
+
+    teacher.emit('draw:append', { e: 'ds', sId: 3, r: SESSION_ID, x: 0.0, y: 0.0, c: '#123456', w: 3 });
+    teacher.emit('draw:append', { e: 'de', sId: 3, r: SESSION_ID, pts: [] });
+    await new Promise((r) => setTimeout(r, 200));
+
+    const raw = await redis.get(`whiteboard:${SESSION_ID}`);
+    const board = JSON.parse(raw);
+    const stroke = board.strokes.find((s) => s.sId === 3);
+
+    expect(stroke.c).toBe('#123456');
+    expect(stroke.w).toBe(3);
+
+    teacher.disconnect();
+  });
+});
+
+// ─── 시나리오 4. sync:state에 c/w 포함 ────────────────────────────────────
+describe('시나리오 4. sync:state', () => {
+  test('재연결 후 sync:state로 받은 strokes에 c, w가 있다', async () => {
+    const teacher = await joinAs('teacher');
+    teacher.emit('draw:append', { e: 'ds', sId: 4, r: SESSION_ID, x: 0.1, y: 0.1, c: '#abcdef', w: 7 });
+    teacher.emit('draw:append', { e: 'de', sId: 4, r: SESSION_ID, pts: [] });
+    await new Promise((r) => setTimeout(r, 200));
+    teacher.disconnect();
+
+    const teacher2 = await joinAs('teacher');
+    const syncPromise = waitFor(teacher2, 'sync:state');
+    teacher2.emit('sync:request', {});
+    const state = await syncPromise;
+
+    const stroke = state.strokes.find((s) => s.sId === 4);
+    expect(stroke?.c).toBe('#abcdef');
+    expect(stroke?.w).toBe(7);
+
+    teacher2.disconnect();
+  });
+});
+
+// ─── 시나리오 5. ds c/w 검증 ──────────────────────────────────────────────
+describe('시나리오 5. ds 검증', () => {
+  test.each([
+    ['문자열 색상명', 'red'],
+    ['빈 문자열', ''],
+    ['8자리 hex', '#12345678'],
+    ['# 없는 hex', '000000'],
+  ])('c=%s → PAYLOAD_INVALID', async (label, c) => {
+    const teacher = await joinAs('teacher');
+    const errPromise = waitFor(teacher, 'server_error');
+    teacher.emit('draw:append', { e: 'ds', sId: 99, r: SESSION_ID, x: 0.1, y: 0.1, c, w: 2 });
+    const err = await errPromise;
+    expect(err.code).toBe('PAYLOAD_INVALID');
+    teacher.disconnect();
+  });
+
+  test('w > 50 → PAYLOAD_INVALID', async () => {
+    const teacher = await joinAs('teacher');
+    const errPromise = waitFor(teacher, 'server_error');
+    teacher.emit('draw:append', { e: 'ds', sId: 100, r: SESSION_ID, x: 0.1, y: 0.1, c: '#000000', w: 51 });
+    const err = await errPromise;
+    expect(err.code).toBe('PAYLOAD_INVALID');
+    teacher.disconnect();
+  });
+
+  test.each([
+    ['3자리 hex', '#abc'],
+    ['6자리 hex', '#aabbcc'],
+    ['대문자 hex', '#AABBCC'],
+  ])('c=%s → 정상 처리', async (label, c) => {
+    const teacher = await joinAs('teacher');
+    const student = await joinAs('student');
+
+    const dsPromise = waitForDrawAppend(student, 'ds');
+    teacher.emit('draw:append', { e: 'ds', sId: 101, r: SESSION_ID, x: 0.1, y: 0.1, c, w: 2 });
+    const ds = await dsPromise;
+    expect(ds.c).toBe(c);
+
+    teacher.disconnect();
+    student.disconnect();
+  });
+});
+
+// ─── 시나리오 6. 구형 데이터 호환성 ───────────────────────────────────────
+describe('시나리오 6. 구형 stroke 호환성', () => {
+  test('c/w 없는 구형 stroke가 Redis에 있어도 sync:state에서 기본값으로 정규화된다', async () => {
+    await redis.set(
+      `whiteboard:${SESSION_ID}`,
+      JSON.stringify({ strokes: [{ sId: 1, x: 0.1, y: 0.1, pts: [], t: 1 }] }),
+      'EX', 3600,
+    );
+    await redis.set(
+      `whiteboardMeta:${SESSION_ID}`,
+      JSON.stringify({ serverTick: 1, hasDestructiveChange: false }),
+      'EX', 3600,
+    );
+
+    const teacher = await joinAs('teacher');
+    const syncPromise = waitFor(teacher, 'sync:state');
+    teacher.emit('sync:request', { lastTick: 0 });
+    const state = await syncPromise;
+
+    const stroke = state.strokes.find((s) => s.sId === 1);
+    expect(stroke?.c).toBe('#000000');
+    expect(stroke?.w).toBe(2);
+
+    teacher.disconnect();
+  });
+});


### PR DESCRIPTION
📌 개요

판서 stroke 데이터에 펜 색상(color)과 굵기(width) 정보를 포함하여
실시간 판서 스트리밍, 재동기화(sync), 저장된 판서 조회 시 동일한 스타일을 재현할 수 있도록 펜 스타일 관리 기능을 추가했습니다.

또한 기존에 저장된 stroke 데이터 중 c, w 정보가 없는 경우에도 정상적으로 렌더링될 수 있도록 **호환성 처리(normalize)**를 적용했습니다.

🛠 주요 구현 내용
1. 펜 스타일 설정 상수 추가

PEN_CONFIG 상수를 추가하여 펜 스타일 관련 설정을 중앙에서 관리하도록 구현했습니다.

기본 색상 (DEFAULT_COLOR)

기본 굵기 (DEFAULT_WIDTH)

최대 굵기 (MAX_WIDTH)

hex 색상 형식 검증 (HEX_RE)

const PEN_CONFIG = {
  DEFAULT_COLOR: "#000000",
  DEFAULT_WIDTH: 2,
  MAX_WIDTH: 50,
  HEX_RE: /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/,
};
2. 구형 stroke 데이터 호환성 처리

기존 데이터 중 color, width 정보가 없는 경우를 대비해
normalizeStroke 헬퍼를 추가하여 기본값으로 보정하도록 구현했습니다.

적용 위치:

GET /whiteboard (ARCHIVED)

GET /whiteboard (ACTIVE)

sync:state 소켓 응답

3. draw 이벤트 검증 강화

ds 이벤트에서 전달되는 펜 스타일 정보의 유효성을 검증하도록 개선했습니다.

검증 항목

color → hex 형식 (#RGB / #RRGGBB)

width → 0 < width ≤ MAX_WIDTH

잘못된 payload는 PAYLOAD_INVALID 오류로 차단됩니다.

4. de 이벤트 브로드캐스트 스타일 보강

de 이벤트에서도 c, w 정보를 포함하도록 수정하여
중간 참여 사용자나 이벤트 누락 상황에서도 스타일이 유지되도록 개선했습니다.

5. 메모리 누수 방지

교사 소켓이 disconnect될 경우
해당 세션의 미완성 stroke 데이터를 pendingStrokes에서 정리하도록 로직을 추가했습니다.

if (socket.data.role === "teacher" && socket.data.roomId) {
  pendingStrokes.delete(socket.data.roomId);
}
6. 통합 테스트 추가

tests/45-pen-style.test.js

다음 시나리오에 대한 통합 테스트를 추가했습니다.

ds 브로드캐스트 시 스타일 포함 여부

de 브로드캐스트 시 스타일 유지

Redis 저장 시 c/w 포함 여부

sync 재연결 시 스타일 유지

ds payload 검증 테스트

구형 stroke 데이터 호환성 테스트

📈 기대 효과

판서 스타일(color, width) 일관성 유지

재접속 및 재동기화 시 동일한 판서 스타일 보장

기존 데이터와의 호환성 유지

draw 이벤트 payload 검증 강화로 데이터 무결성 확보