### PR TITLE
[Feat]: #47- stroke에 page 메타데이터 추가 및 저장 로직 반영

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -42,11 +42,15 @@ const PEN_CONFIG = {
 // ✅ #45: 구형 stroke 데이터(c/w 없음) 정규화
 function normalizeStroke(s) {
   if (!s) return s;
-  return {
+  const normalized = {
     ...s,
     c: (typeof s.c === "string" && PEN_CONFIG.HEX_RE.test(s.c)) ? s.c : PEN_CONFIG.DEFAULT_COLOR,
     w: (typeof s.w === "number" && s.w > 0 && s.w <= PEN_CONFIG.MAX_WIDTH) ? s.w : PEN_CONFIG.DEFAULT_WIDTH,
   };
+  if (!(Number.isInteger(s.page) && s.page >= 1)) {
+    delete normalized.page;
+  }
+  return normalized;
 }
 
 // ✅ #74: room별 진행 중인 stroke 임시 저장 (ds → de 완성 전까지)
@@ -1558,17 +1562,20 @@ socket.on(SOCKET_EVENTS.DRAW_APPEND, async (payload) => {
         typeof payload.x !== "number" || payload.x < 0 || payload.x > 1 ||
         typeof payload.y !== "number" || payload.y < 0 || payload.y > 1 ||
         typeof payload.c !== "string" || !PEN_CONFIG.HEX_RE.test(payload.c) ||
-        typeof payload.w !== "number" || payload.w <= 0 || payload.w > PEN_CONFIG.MAX_WIDTH) {
+        typeof payload.w !== "number" || payload.w <= 0 || payload.w > PEN_CONFIG.MAX_WIDTH ||
+      (payload.page !== undefined && (!Number.isInteger(payload.page) || payload.page < 1))) {
       return socket.emit(SOCKET_EVENTS.ERROR, {
         code: ERRORS.PAYLOAD_INVALID,
         message: "INVALID_DS_PAYLOAD",
       });
     }
     // ✅ #74: ds 데이터를 pendingStrokes에 임시 보관 (de 완성 시 Redis 저장에 사용)
+    // ✅ #47: page는 stroke 시작 시점(ds) 기준으로 고정
     const sid = socket.data.roomId;
     if (!pendingStrokes.has(sid)) pendingStrokes.set(sid, new Map());
     pendingStrokes.get(sid).set(payload.sId, {
       sId: payload.sId, x: payload.x, y: payload.y, c: payload.c, w: payload.w,
+      ...(Number.isInteger(payload.page) && payload.page >= 1 && { page: payload.page }),
     });
   }
 
@@ -1660,6 +1667,7 @@ socket.on(SOCKET_EVENTS.DRAW_APPEND, async (payload) => {
         w: dsData?.w ?? PEN_CONFIG.DEFAULT_WIDTH,
         pts: Array.isArray(payload.pts) ? payload.pts : [],
         t: tick,
+        ...(dsData?.page !== undefined && { page: dsData.page }),
       };
 
       // 락 획득 후 GET → parse → upsert → SET (원자적 보장)


### PR DESCRIPTION
📌 개요
PDF 기반 판서 복원 및 재생을 위해,
각 stroke가 어느 페이지에서 생성되었는지 추적할 수 있도록
page 메타데이터를 stroke 저장 구조에 추가했습니다.

🛠 주요 변경 사항
ds 이벤트에서 page 정보 저장
de 처리 시 Redis 및 파일 저장에 page 포함
normalizeStroke에 page 정규화 추가
기존 데이터와의 하위 호환 유지

⚠️ 참고 사항
materialId는 세션 단위로 관리되므로 stroke에는 포함하지 않음
page는 stroke 시작 시점 기준으로 고정

✅ 기대 효과
PDF 판서 위치 정확한 복원 가능
replay 및 PDF 합성 기능 구현 기반 마련