### PR TITLE
[Feat]: #50 세션 입장 시 교사 판서(de 리스트) full sync 전송

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1648,6 +1648,42 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
       user: { userId: socket.data.userId, role: socket.data.role }
     });
 
+    // ✅ #50: join 시 현재 판서 상태 full sync
+    try {
+      const [rawBoard, rawMeta] = await Promise.all([
+        redis.get(`whiteboard:${roomId}`),
+        redis.get(`whiteboardMeta:${roomId}`),
+      ]);
+
+      let strokes = [];
+      let serverTick = 0;
+
+      if (rawBoard) {
+        try {
+          const board = JSON.parse(rawBoard);
+          strokes = Array.isArray(board?.strokes) ? board.strokes : [];
+        } catch (_) {}
+      }
+
+      if (rawMeta) {
+        try {
+          const meta = JSON.parse(rawMeta);
+          serverTick = Number.isInteger(meta?.serverTick) ? meta.serverTick : 0;
+        } catch (_) {}
+      }
+
+      socket.emit(SOCKET_EVENTS.SYNC_STATE, {
+        mode: 'full',
+        strokes: strokes.map(normalizeStroke),
+        serverTick,
+      });
+    } catch (err) {
+      logger.warn('join: initial sync failed', {
+        roomId,
+        err: err?.message,
+      });
+    }
+
     // ✅ #44: 재연결 시 TTL 갱신 (키 없으면 expire는 무시됨 → allSettled)
     await Promise.allSettled([
       redis.expire(`session:${roomId}`, APP_CONFIG.SESSION_TTL_SECONDS),


### PR DESCRIPTION
## 🛠 Issue
세션 입장 시 기존 교사 판서(de 리스트)를 자동으로 전송하여
클라이언트가 현재 수업 상태와 동일한 화면을 즉시 렌더링할 수 있도록 구현

## ✨ 변경 내용
- JOIN_SUCCESS 이후 Redis에서 판서 데이터 조회
- sync:state 이벤트(mode: 'full')로 전체 판서 상태 전송
- 판서가 없는 경우 빈 배열([]) 전송
- serverTick 함께 전달하여 클라이언트 상태 정렬 가능

## 💡 설계 의도
- 초기 입장 시에는 delta가 아닌 full sync 방식 사용
- 기존 sync:request는 재연결 복구용으로 유지
- 판서 조회 실패 시에도 join 자체는 정상 처리 (try/catch 적용)

## ⚠️ 참고 사항
- 현재는 단일 payload 전송 방식이며,
  대용량 세션에 대한 chunking은 추후 개선 예정
 - 클라이언트 측 확인 필요:
    - join 후 sync:request를 자동으로 재전송하지 않는지
    - JOIN_SUCCESS 직후 SYNC_STATE를 받아도 안전하게 처리 가능한지