### PR TITLE
[Refactor]: #50 join 시 full sync 제거 및 sync 흐름 통일

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1648,42 +1648,6 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
       user: { userId: socket.data.userId, role: socket.data.role }
     });
 
-    // ✅ #50: join 시 현재 판서 상태 full sync
-    try {
-      const [rawBoard, rawMeta] = await Promise.all([
-        redis.get(`whiteboard:${roomId}`),
-        redis.get(`whiteboardMeta:${roomId}`),
-      ]);
-
-      let strokes = [];
-      let serverTick = 0;
-
-      if (rawBoard) {
-        try {
-          const board = JSON.parse(rawBoard);
-          strokes = Array.isArray(board?.strokes) ? board.strokes : [];
-        } catch (_) {}
-      }
-
-      if (rawMeta) {
-        try {
-          const meta = JSON.parse(rawMeta);
-          serverTick = Number.isInteger(meta?.serverTick) ? meta.serverTick : 0;
-        } catch (_) {}
-      }
-
-      socket.emit(SOCKET_EVENTS.SYNC_STATE, {
-        mode: 'full',
-        strokes: strokes.map(normalizeStroke),
-        serverTick,
-      });
-    } catch (err) {
-      logger.warn('join: initial sync failed', {
-        roomId,
-        err: err?.message,
-      });
-    }
-
     // ✅ #44: 재연결 시 TTL 갱신 (키 없으면 expire는 무시됨 → allSettled)
     await Promise.allSettled([
       redis.expire(`session:${roomId}`, APP_CONFIG.SESSION_TTL_SECONDS),


### PR DESCRIPTION
## 🛠 변경 내용
- join 시 서버에서 sync:state(full) 즉시 push하던 로직 제거
- 클라이언트가 JOIN_SUCCESS 이후 sync:request를 통해 상태를 요청하도록 변경

## ✨ 개선 사항
- 초기 입장과 재연결 흐름을 sync:request → sync:state로 통일
- 클라이언트 초기화 타이밍 문제로 인한 동기화 누락 가능성 제거
- 동기화 로직 단순화 및 유지보수성 향상

## ⚠️ 참고
- 프론트에서 JOIN_SUCCESS 이후 반드시 sync:request 호출 필요