### PR TITLE
[Fix] #100 Question FK 제약 제거 및 Redis 세션 구조와 불일치 문제 해결

### DIFF
--- a/prisma/migrations/20260403000000_add_question/migration.sql
+++ b/prisma/migrations/20260403000000_add_question/migration.sql
@@ -12,10 +12,5 @@ CREATE TABLE "Question" (
     CONSTRAINT "Question_pkey" PRIMARY KEY ("id")
 );
 
--- AddForeignKey
-ALTER TABLE "Question"
-    ADD CONSTRAINT "Question_sessionId_fkey"
-    FOREIGN KEY ("sessionId") REFERENCES "Session"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
 -- CreateIndex
 CREATE INDEX "Question_sessionId_createdAt_idx" ON "Question"("sessionId", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -116,8 +116,6 @@ model Session {
   endAttempts Int           @default(0)
   endError    String?
   createdAt   DateTime      @default(now())
-  questions   Question[]
-
   @@index([classId, createdAt])
   @@index([status])
 }
@@ -125,7 +123,6 @@ model Session {
 model Question {
   id        String         @id @default(cuid())
   sessionId String
-  session   Session        @relation(fields: [sessionId], references: [id], onDelete: Cascade)
   userId    String
   content   String
   status    QuestionStatus @default(PENDING)

--- a/scripts/question-test.js
+++ b/scripts/question-test.js
@@ -1,0 +1,142 @@
+/**
+ * #54 question 기능 테스트
+ *
+ * 시나리오:
+ *   1. 학생 질문 전송 → QUESTION_ACK 수신 확인
+ *   2. 교사가 QUESTION_NEW 실시간 수신 확인
+ *   3. 빈 문자열 전송 → QUESTION_EMPTY 에러 확인
+ *   4. 길이 초과 전송 → QUESTION_TOO_LONG 에러 확인
+ *   5. 교사가 QUESTION_LIST 요청 → 저장된 질문 목록 확인
+ *   6. 학생이 QUESTION_LIST 요청 → FORBIDDEN 에러 확인
+ */
+
+require("dotenv").config();
+const { io: ioClient } = require("socket.io-client");
+const { signToken } = require("../src/utils/jwt");
+
+const BASE = "http://localhost:3000";
+
+const teacherToken = signToken({ userId: "teacher-question-test", role: "teacher" });
+const studentToken = signToken({ userId: "student-question-test", role: "student" });
+
+async function createSession() {
+  const res = await fetch(`${BASE}/session/create`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ classId: process.env.TEST_CLASS_ID || "test-class" }),
+  });
+  const data = await res.json();
+  if (!data.sessionId) throw new Error("세션 생성 실패: " + JSON.stringify(data));
+  return data.sessionId;
+}
+
+function connectSocket(token) {
+  return ioClient(BASE, {
+    auth: { token },
+    transports: ["websocket"],
+    autoConnect: false,
+  });
+}
+
+function waitForEvent(socket, event, timeoutMs = 4000) {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(`TIMEOUT: ${event}`)), timeoutMs);
+    socket.once(event, (data) => {
+      clearTimeout(t);
+      resolve(data);
+    });
+  });
+}
+
+async function joinRoom(socket, sessionId, label) {
+  await new Promise((resolve, reject) => {
+    socket.once("connect", () => socket.emit("join_room", { roomId: sessionId }));
+    socket.once("join_success", resolve);
+    socket.once("server_error", (e) => reject(new Error(`[${label}] server_error: ${JSON.stringify(e)}`)));
+    socket.connect();
+  });
+}
+
+async function run() {
+  console.log("[TEST] question 기능 테스트 시작\n");
+
+  const sessionId = await createSession();
+  console.log(`[SETUP] 세션 생성: ${sessionId}\n`);
+
+  const teacher = connectSocket(teacherToken);
+  const student  = connectSocket(studentToken);
+
+  await joinRoom(teacher, sessionId, "TEACHER");
+  console.log("[SETUP] 교사 join 완료");
+  await joinRoom(student, sessionId, "STUDENT");
+  console.log("[SETUP] 학생 join 완료\n");
+
+  // --- 시나리오 1 & 2: 학생 질문 전송 → ACK + 교사 NEW ---
+  console.log("--- 시나리오 1 & 2: 질문 전송 → ACK / 교사 NEW ---");
+  const ackPromise     = waitForEvent(student, "question:ack");
+  const newPromise     = waitForEvent(teacher, "question:new");
+
+  student.emit("question:ask", { content: "판서 내용이 잘 안 보여요" });
+
+  const ack = await ackPromise;
+  console.log("[STUDENT] question:ack 수신:", JSON.stringify(ack));
+  console.assert(ack.questionId,                         "questionId 없음");
+  console.assert(ack.content === "판서 내용이 잘 안 보여요", "content 불일치");
+  console.assert(ack.status === "PENDING",               "status가 PENDING이어야 함");
+  console.assert(typeof ack.askedAt === "number",        "askedAt이 숫자여야 함");
+  console.log("[OK] question:ack 검증 통과");
+
+  const questionNew = await newPromise;
+  console.log("[TEACHER] question:new 수신:", JSON.stringify(questionNew));
+  console.assert(questionNew.questionId === ack.questionId,       "questionId 불일치");
+  console.assert(questionNew.askedBy.userId === "student-question-test", "askedBy.userId 불일치");
+  console.log("[OK] question:new 검증 통과\n");
+
+  // --- 시나리오 3: 빈 문자열 ---
+  console.log("--- 시나리오 3: 빈 문자열 → QUESTION_EMPTY ---");
+  const emptyErrPromise = waitForEvent(student, "server_error");
+  student.emit("question:ask", { content: "   " });
+  const emptyErr = await emptyErrPromise;
+  console.log("[STUDENT] server_error 수신:", JSON.stringify(emptyErr));
+  console.assert(emptyErr.code === "QUESTION_EMPTY", `QUESTION_EMPTY여야 함, 실제: ${emptyErr.code}`);
+  console.log("[OK] 빈 문자열 에러 검증 통과\n");
+
+  // --- 시나리오 4: 길이 초과 ---
+  console.log("--- 시나리오 4: 길이 초과 → QUESTION_TOO_LONG ---");
+  const longErrPromise = waitForEvent(student, "server_error");
+  student.emit("question:ask", { content: "A".repeat(501) });
+  const longErr = await longErrPromise;
+  console.log("[STUDENT] server_error 수신:", JSON.stringify(longErr));
+  console.assert(longErr.code === "QUESTION_TOO_LONG", `QUESTION_TOO_LONG이어야 함, 실제: ${longErr.code}`);
+  console.log("[OK] 길이 초과 에러 검증 통과\n");
+
+  // --- 시나리오 5: 교사 question:list ---
+  console.log("--- 시나리오 5: 교사 question:list 조회 ---");
+  const listPromise = waitForEvent(teacher, "question:list:result");
+  teacher.emit("question:list");
+  const listResult = await listPromise;
+  console.log("[TEACHER] question:list:result 수신:", JSON.stringify(listResult));
+  console.assert(Array.isArray(listResult.questions),          "questions가 배열이어야 함");
+  console.assert(listResult.questions.length >= 1,             "질문이 1개 이상이어야 함");
+  console.assert(listResult.questions[0].content === "판서 내용이 잘 안 보여요", "첫 번째 질문 content 불일치");
+  console.log("[OK] question:list 검증 통과\n");
+
+  // --- 시나리오 6: 학생이 question:list 요청 → FORBIDDEN ---
+  console.log("--- 시나리오 6: 학생 question:list → FORBIDDEN ---");
+  const forbiddenPromise = waitForEvent(student, "server_error");
+  student.emit("question:list");
+  const forbidden = await forbiddenPromise;
+  console.log("[STUDENT] server_error 수신:", JSON.stringify(forbidden));
+  console.assert(forbidden.code === "FORBIDDEN", `FORBIDDEN이어야 함, 실제: ${forbidden.code}`);
+  console.log("[OK] 학생 접근 차단 검증 통과\n");
+
+  teacher.disconnect();
+  student.disconnect();
+
+  console.log("=== [RESULT] 모든 시나리오 통과 ✅ ===");
+}
+
+run().catch((err) => {
+  console.error("\n[RESULT] 테스트 실패:", err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## 🛠 Issue
Question 저장 시 sessionId가 DB Session을 참조하도록 FK가 설정되어 있었으나,
현재 세션은 Redis에만 저장되고 있어 FK 제약 위반 오류가 발생함.

이를 해결하기 위해 Question 모델에서 Session과의 FK 관계를 제거하고,
sessionId를 문자열로 관리하도록 수정.

## 📝 주요 변경 사항
- Question 모델에서 Session FK 제거
- Prisma schema 및 migration 수정
- Redis 기반 세션 구조에 맞게 저장 로직 정렬
- 테스트 스크립트(joinRoom) 이벤트 리스너 수정 (on → once)

## 📌 기타
- 세션은 Redis를 source of truth로 유지
- Question은 DB에서 sessionId 문자열 기준으로 관리