### PR TITLE
[Feat]: #55 질문 익명 처리(isAnonymous) 및 테스트 추가

### DIFF
--- a/prisma/migrations/20260403010000_add_question_anonymous/migration.sql
+++ b/prisma/migrations/20260403010000_add_question_anonymous/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Question" ADD COLUMN "isAnonymous" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -121,12 +121,13 @@ model Session {
 }
 
 model Question {
-  id        String         @id @default(cuid())
-  sessionId String
-  userId    String
-  content   String
-  status    QuestionStatus @default(PENDING)
-  createdAt DateTime       @default(now())
+  id          String         @id @default(cuid())
+  sessionId   String
+  userId      String
+  content     String
+  status      QuestionStatus @default(PENDING)
+  isAnonymous Boolean        @default(false)
+  createdAt   DateTime       @default(now())
 
   @@index([sessionId, createdAt])
 }

--- a/scripts/question-test.js
+++ b/scripts/question-test.js
@@ -1,13 +1,15 @@
 /**
- * #54 question 기능 테스트
+ * #54 + #55 question 기능 테스트
  *
  * 시나리오:
- *   1. 학생 질문 전송 → QUESTION_ACK 수신 확인
- *   2. 교사가 QUESTION_NEW 실시간 수신 확인
- *   3. 빈 문자열 전송 → QUESTION_EMPTY 에러 확인
- *   4. 길이 초과 전송 → QUESTION_TOO_LONG 에러 확인
- *   5. 교사가 QUESTION_LIST 요청 → 저장된 질문 목록 확인
- *   6. 학생이 QUESTION_LIST 요청 → FORBIDDEN 에러 확인
+ *   1. 학생 질문 전송 (익명 X) → QUESTION_ACK 수신 확인
+ *   2. 교사가 QUESTION_NEW 실시간 수신 확인 (askedBy.userId 존재)
+ *   3. 학생 익명 질문 전송 → ACK isAnonymous=true 확인
+ *   4. 교사가 익명 QUESTION_NEW 수신 → askedBy.userId=null 확인
+ *   5. 빈 문자열 전송 → QUESTION_EMPTY 에러 확인
+ *   6. 길이 초과 전송 → QUESTION_TOO_LONG 에러 확인
+ *   7. 교사가 QUESTION_LIST 요청 → 저장된 질문 목록 확인 (마스킹 포함)
+ *   8. 학생이 QUESTION_LIST 요청 → FORBIDDEN 에러 확인
  */
 
 require("dotenv").config();
@@ -71,29 +73,48 @@ async function run() {
   await joinRoom(student, sessionId, "STUDENT");
   console.log("[SETUP] 학생 join 완료\n");
 
-  // --- 시나리오 1 & 2: 학생 질문 전송 → ACK + 교사 NEW ---
-  console.log("--- 시나리오 1 & 2: 질문 전송 → ACK / 교사 NEW ---");
-  const ackPromise     = waitForEvent(student, "question:ack");
-  const newPromise     = waitForEvent(teacher, "question:new");
+  // --- 시나리오 1 & 2: 일반 질문 ---
+  console.log("--- 시나리오 1 & 2: 일반 질문 → ACK / 교사 NEW ---");
+  const ackPromise = waitForEvent(student, "question:ack");
+  const newPromise = waitForEvent(teacher, "question:new");
 
-  student.emit("question:ask", { content: "판서 내용이 잘 안 보여요" });
+  student.emit("question:ask", { content: "판서 내용이 잘 안 보여요", isAnonymous: false });
 
   const ack = await ackPromise;
   console.log("[STUDENT] question:ack 수신:", JSON.stringify(ack));
-  console.assert(ack.questionId,                         "questionId 없음");
-  console.assert(ack.content === "판서 내용이 잘 안 보여요", "content 불일치");
-  console.assert(ack.status === "PENDING",               "status가 PENDING이어야 함");
-  console.assert(typeof ack.askedAt === "number",        "askedAt이 숫자여야 함");
+  console.assert(ack.questionId,                              "questionId 없음");
+  console.assert(ack.content === "판서 내용이 잘 안 보여요",    "content 불일치");
+  console.assert(ack.status === "PENDING",                    "status가 PENDING이어야 함");
+  console.assert(ack.isAnonymous === false,                   "isAnonymous가 false여야 함");
   console.log("[OK] question:ack 검증 통과");
 
   const questionNew = await newPromise;
   console.log("[TEACHER] question:new 수신:", JSON.stringify(questionNew));
-  console.assert(questionNew.questionId === ack.questionId,       "questionId 불일치");
-  console.assert(questionNew.askedBy.userId === "student-question-test", "askedBy.userId 불일치");
+  console.assert(questionNew.questionId === ack.questionId,                      "questionId 불일치");
+  console.assert(questionNew.askedBy.userId === "student-question-test",          "askedBy.userId 불일치");
+  console.assert(questionNew.askedBy.isAnonymous === false,                       "askedBy.isAnonymous가 false여야 함");
   console.log("[OK] question:new 검증 통과\n");
 
-  // --- 시나리오 3: 빈 문자열 ---
-  console.log("--- 시나리오 3: 빈 문자열 → QUESTION_EMPTY ---");
+  // --- 시나리오 3 & 4: 익명 질문 ---
+  console.log("--- 시나리오 3 & 4: 익명 질문 → ACK isAnonymous=true / 교사 NEW userId=null ---");
+  const anonAckPromise = waitForEvent(student, "question:ack");
+  const anonNewPromise = waitForEvent(teacher, "question:new");
+
+  student.emit("question:ask", { content: "이 부분 다시 설명해 주세요", isAnonymous: true });
+
+  const anonAck = await anonAckPromise;
+  console.log("[STUDENT] question:ack 수신:", JSON.stringify(anonAck));
+  console.assert(anonAck.isAnonymous === true, "isAnonymous가 true여야 함");
+  console.log("[OK] 익명 ACK 검증 통과");
+
+  const anonNew = await anonNewPromise;
+  console.log("[TEACHER] question:new 수신:", JSON.stringify(anonNew));
+  console.assert(anonNew.askedBy.userId === null,        "익명 질문 askedBy.userId가 null이어야 함");
+  console.assert(anonNew.askedBy.isAnonymous === true,   "askedBy.isAnonymous가 true여야 함");
+  console.log("[OK] 익명 question:new 검증 통과\n");
+
+  // --- 시나리오 5: 빈 문자열 ---
+  console.log("--- 시나리오 5: 빈 문자열 → QUESTION_EMPTY ---");
   const emptyErrPromise = waitForEvent(student, "server_error");
   student.emit("question:ask", { content: "   " });
   const emptyErr = await emptyErrPromise;
@@ -101,8 +122,8 @@ async function run() {
   console.assert(emptyErr.code === "QUESTION_EMPTY", `QUESTION_EMPTY여야 함, 실제: ${emptyErr.code}`);
   console.log("[OK] 빈 문자열 에러 검증 통과\n");
 
-  // --- 시나리오 4: 길이 초과 ---
-  console.log("--- 시나리오 4: 길이 초과 → QUESTION_TOO_LONG ---");
+  // --- 시나리오 6: 길이 초과 ---
+  console.log("--- 시나리오 6: 길이 초과 → QUESTION_TOO_LONG ---");
   const longErrPromise = waitForEvent(student, "server_error");
   student.emit("question:ask", { content: "A".repeat(501) });
   const longErr = await longErrPromise;
@@ -110,19 +131,22 @@ async function run() {
   console.assert(longErr.code === "QUESTION_TOO_LONG", `QUESTION_TOO_LONG이어야 함, 실제: ${longErr.code}`);
   console.log("[OK] 길이 초과 에러 검증 통과\n");
 
-  // --- 시나리오 5: 교사 question:list ---
-  console.log("--- 시나리오 5: 교사 question:list 조회 ---");
+  // --- 시나리오 7: 교사 question:list ---
+  console.log("--- 시나리오 7: 교사 question:list 조회 ---");
   const listPromise = waitForEvent(teacher, "question:list:result");
   teacher.emit("question:list");
   const listResult = await listPromise;
   console.log("[TEACHER] question:list:result 수신:", JSON.stringify(listResult));
-  console.assert(Array.isArray(listResult.questions),          "questions가 배열이어야 함");
-  console.assert(listResult.questions.length >= 1,             "질문이 1개 이상이어야 함");
-  console.assert(listResult.questions[0].content === "판서 내용이 잘 안 보여요", "첫 번째 질문 content 불일치");
+  console.assert(Array.isArray(listResult.questions),        "questions가 배열이어야 함");
+  console.assert(listResult.questions.length >= 2,           "질문이 2개 이상이어야 함");
+  const anonQ = listResult.questions.find(q => q.askedBy.isAnonymous === true);
+  const normalQ = listResult.questions.find(q => q.askedBy.isAnonymous === false);
+  console.assert(anonQ && anonQ.askedBy.userId === null,             "익명 질문 userId가 null이어야 함");
+  console.assert(normalQ && normalQ.askedBy.userId === "student-question-test", "일반 질문 userId 불일치");
   console.log("[OK] question:list 검증 통과\n");
 
-  // --- 시나리오 6: 학생이 question:list 요청 → FORBIDDEN ---
-  console.log("--- 시나리오 6: 학생 question:list → FORBIDDEN ---");
+  // --- 시나리오 8: 학생이 question:list 요청 → FORBIDDEN ---
+  console.log("--- 시나리오 8: 학생 question:list → FORBIDDEN ---");
   const forbiddenPromise = waitForEvent(student, "server_error");
   student.emit("question:list");
   const forbidden = await forbiddenPromise;

--- a/src/server.js
+++ b/src/server.js
@@ -272,6 +272,14 @@ function isValidPollOptions(options) {
   return true;
 }
 
+/// ✅ #55: 익명 여부에 따라 askedBy 구성
+// userId: null → 익명 사용자 (프론트에서 "익명" 등으로 표시). 문구/아이콘 결정은 클라이언트 담당
+function resolveAskedBy(userId, isAnonymous) {
+  return isAnonymous
+    ? { userId: null, isAnonymous: true }
+    : { userId, isAnonymous: false };
+}
+
 // ✅ #51: 투표 종료 공통 처리 (타이머 만료 / 교사 조기 종료 / 세션 종료 모두 이 경로)
 function endPoll(io, sessionId) {
   const poll = activePolls.get(sessionId);
@@ -2039,8 +2047,8 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
     endPoll(io, sessionId);
   });
 
-  // ✅ #54: 학생 질문 수신 → DB 저장 → 교사에게 전달
-  socket.on(SOCKET_EVENTS.QUESTION_ASK, async ({ content } = {}) => {
+  // ✅ #54 + #55: 학생 질문 수신 → DB 저장 → 교사에게 전달
+  socket.on(SOCKET_EVENTS.QUESTION_ASK, async ({ content, isAnonymous = false } = {}) => {
     if (!requireStudent(socket)) {
       return socket.emit(SOCKET_EVENTS.ERROR, { code: ERRORS.FORBIDDEN, message: "Students only" });
     }
@@ -2052,7 +2060,9 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
       return socket.emit(SOCKET_EVENTS.ERROR, { code: ERRORS.QUESTION_EMPTY, message: "질문 내용이 비어 있습니다" });
     }
 
-    const trimmed = content.trim();
+    const trimmed  = content.trim();
+    // boolean이 아닌 값(예: 문자열 "true")은 false로 간주
+    const anonymous = isAnonymous === true;
 
     if (!trimmed) {
       return socket.emit(SOCKET_EVENTS.ERROR, { code: ERRORS.QUESTION_EMPTY, message: "질문 내용이 비어 있습니다" });
@@ -2069,7 +2079,7 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
     for (let attempt = 1; attempt <= 2; attempt++) {
       try {
         question = await prisma.question.create({
-          data: { sessionId, userId, content: trimmed },
+          data: { sessionId, userId, content: trimmed, isAnonymous: anonymous },
         });
         break;
       } catch (err) {
@@ -2080,24 +2090,26 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
       }
     }
 
+    // ACK: 본인에게만 반환. 마스킹 없이 isAnonymous를 최상위에 포함
     socket.emit(SOCKET_EVENTS.QUESTION_ACK, {
-      questionId: question.id,
-      content:    question.content,
-      status:     question.status,
-      askedAt:    question.createdAt.getTime(),
+      questionId:  question.id,
+      content:     question.content,
+      status:      question.status,
+      isAnonymous: question.isAnonymous,
+      askedAt:     question.createdAt.getTime(),
     });
 
-    // 익명 질문 정책: teacher 룸 전용 broadcast
+    // QUESTION_NEW: 교사에게 broadcast. askedBy 내부에 isAnonymous 포함
     const { teachersRoom } = getRoleRooms(sessionId);
     io.to(teachersRoom).emit(SOCKET_EVENTS.QUESTION_NEW, {
       questionId: question.id,
       content:    question.content,
-      askedBy:    { userId },
+      askedBy:    resolveAskedBy(userId, anonymous),
       status:     question.status,
       askedAt:    question.createdAt.getTime(),
     });
 
-    logger.info("❓ question received", { sessionId, userId, questionId: question.id });
+    logger.info("❓ question received", { sessionId, userId, questionId: question.id, isAnonymous: anonymous });
   });
 
   // ✅ #54: 교사 질문 목록 조회 (재접속 sync 용)
@@ -2116,7 +2128,7 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
       questions = await prisma.question.findMany({
         where:   { sessionId },
         orderBy: { createdAt: "asc" },
-        select:  { id: true, userId: true, content: true, status: true, createdAt: true },
+        select:  { id: true, userId: true, content: true, status: true, isAnonymous: true, createdAt: true },
       });
     } catch (err) {
       logger.error("question list failed", { sessionId, err });
@@ -2127,7 +2139,7 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
       questions: questions.map(q => ({
         questionId: q.id,
         content:    q.content,
-        askedBy:    { userId: q.userId },
+        askedBy:    resolveAskedBy(q.userId, q.isAnonymous),
         status:     q.status,
         askedAt:    q.createdAt.getTime(),
       })),


### PR DESCRIPTION
## 🛠 Issue
#55 질문 익명 처리 기능 구현

## ✨ What’s Done
- Question 모델에 isAnonymous 필드 추가
- 익명 질문 시 userId를 null로 마스킹 (서버 처리)
- resolveAskedBy 헬퍼 함수로 payload 구조 통일
- QUESTION_NEW / QUESTION_LIST_RESULT에서 askedBy.isAnonymous 포함
- QUESTION_ACK는 예외적으로 최상위 isAnonymous 포함
- boolean이 아닌 값 방어 처리 (isAnonymous === true)

## 🧪 Test
- 일반 질문 (isAnonymous=false)
  - ACK: isAnonymous=false
  - NEW: askedBy.userId 정상, isAnonymous=false
- 익명 질문 (isAnonymous=true)
  - ACK: isAnonymous=true
  - NEW: askedBy.userId=null, isAnonymous=true
- question:list
  - 익명 질문: userId=null
  - 일반 질문: userId 유지
- 에러 케이스
  - 빈 문자열 → QUESTION_EMPTY
  - 길이 초과 → QUESTION_TOO_LONG
  - 학생 question:list 요청 → FORBIDDEN

## 📌 Note
- userId가 null이면 익명 사용자로 간주
- 실제 표시 문구(“익명” 등)는 클라이언트에서 결정
- 현재 question:list는 교사 전용 기준으로 구현