### PR TITLE
[Feat]: #79 - rollback session to ACTIVE on S3 upload failure

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1334,9 +1334,19 @@ app.post(ROUTES.SESSION_END, requireAuth, requireTeacherRole, async (req, res) =
     });
     const whiteboardData = { strokes };
 
-    // 6. 판서 JSON S3 저장
+    // 6. 판서 JSON S3 저장 (실패 시 DB ACTIVE 롤백 → 교사 재시도 가능)
     const s3Key = `whiteboards/${sessionId}.json`;
-    await uploadString(s3Key, JSON.stringify(whiteboardData));
+    try {
+      await uploadString(s3Key, JSON.stringify(whiteboardData));
+    } catch (s3Err) {
+      const errorMessage = String(s3Err?.message || s3Err || 'S3_UPLOAD_FAILED').slice(0, 500);
+      await prisma.session.update({
+        where: { id: sessionId },
+        data: { status: 'ACTIVE', endError: errorMessage },
+      });
+      logger.error("session end: S3 upload failed, rolled back to ACTIVE", { sessionId, err: errorMessage });
+      return sendHttpError(res, 500, ERRORS.INTERNAL_ERROR, "SESSION_END_FAILED");
+    }
 
     // 7. 파일 저장 성공 후 Redis TTL 설정 (즉시 DEL 하지 않음)
     // ✅ #44: whiteboard와 whiteboardMeta 함께 축소 (meta만 남으면 복원 판단 미묘해짐)


### PR DESCRIPTION
## 📌 작업 내용
S3 업로드 실패 시 세션이 종료되지 못하고 중간 상태에 머무르는 문제를 개선했습니다.

- S3 업로드 실패 시 session 상태를 ACTIVE로 롤백
- endError 필드에 에러 메시지 기록 (최대 500자 제한)
- 교사가 세션 종료를 재시도할 수 있도록 개선

## 🔧 변경 사항
- S3 업로드 로직에 try-catch 추가
- 실패 시 DB 상태 업데이트 및 로그 처리 개선

## 🚧 미완료
- 재시도 로직은 추후 구현 예정 (#79 To-do 중 일부)

## ✅ 테스트
- S3 업로드 실패 시 ACTIVE로 정상 롤백되는지 확인