### PR TITLE
[Feat] #112 - 페이지 단위 판서 sync 요청 및 복원 구현

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -64,10 +64,10 @@ function normalizeStroke(s) {
 }
 
 function pageWbKey(sessionId, materialId, pageNumber) {
-  return `whiteboard:${sessionId}:${materialId}:${pageNumber}`;
+  return `whiteboard:${sessionId}:${encodeURIComponent(materialId)}:${pageNumber}`;
 }
 function pageMetaKey(sessionId, materialId, pageNumber) {
-  return `whiteboardMeta:${sessionId}:${materialId}:${pageNumber}`;
+  return `whiteboardMeta:${sessionId}:${encodeURIComponent(materialId)}:${pageNumber}`;
 }
 
 // ✅ #61: hex 색상 → pdf-lib rgb 변환 (#RGB, #RRGGBB 모두 지원)
@@ -1767,8 +1767,8 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
 
   });
 
-  // ✅ #44: sync:request (재연결 시 lastTick 기반 delta 또는 full sync)
-  socket.on(SOCKET_EVENTS.SYNC_REQUEST, async ({ lastTick } = {}) => {
+  // ✅ #112: sync:request (페이지 단위, lastTick 기반 delta 또는 full sync)
+  socket.on(SOCKET_EVENTS.SYNC_REQUEST, async ({ materialId, pageNumber, lastTick } = {}) => {
     if (!requireJoined(socket)) {
       return socket.emit(SOCKET_EVENTS.ERROR, {
         code: ERRORS.NOT_JOINED,
@@ -1776,13 +1776,31 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
       });
     }
 
-    const roomId = socket.data.roomId;
-    const wbKey = `whiteboard:${roomId}`;
-    const metaKey = `whiteboardMeta:${roomId}`;
+    const normalizedMaterialId =
+      typeof materialId === "string" ? materialId.trim() : "";
+    const normalizedPageNumber = Number(pageNumber);
 
-    // 정수 + 0 이상만 유효 (NaN, 음수, 소수 제외)
+    if (
+      !normalizedMaterialId ||
+      !Number.isInteger(normalizedPageNumber) ||
+      normalizedPageNumber < 1
+    ) {
+      return socket.emit(SOCKET_EVENTS.ERROR, {
+        code: ERRORS.PAYLOAD_INVALID,
+        message: "INVALID_SYNC_REQUEST",
+      });
+    }
+
+    const roomId = socket.data.roomId;
+    const wbKey = pageWbKey(roomId, normalizedMaterialId, normalizedPageNumber);
+    const metaKey = pageMetaKey(roomId, normalizedMaterialId, normalizedPageNumber);
+
+    const normalizedLastTick =
+      lastTick === undefined || lastTick === null ? null : Number(lastTick);
     const clientLastTick =
-      Number.isInteger(lastTick) && lastTick >= 0 ? lastTick : null;
+      Number.isInteger(normalizedLastTick) && normalizedLastTick >= 0
+        ? normalizedLastTick
+        : null;
 
     try {
       const [rawBoard, rawMeta] = await Promise.all([
@@ -1796,11 +1814,14 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
           const parsed = JSON.parse(rawBoard);
           strokes = Array.isArray(parsed?.strokes) ? parsed.strokes : [];
         } catch (e) {
-          logger.warn("invalid whiteboard json on sync", { roomId, err: e?.message });
+          logger.warn("invalid whiteboard json on sync", {
+            roomId, materialId: normalizedMaterialId, pageNumber: normalizedPageNumber,
+            err: e?.message,
+          });
         }
       }
 
-      // meta 파싱 실패 시 보수적으로 hasDestructiveChange: true
+      // meta 파싱 실패 시 보수적으로 hasDestructiveChange: true → 항상 full sync
       let meta = { serverTick: 0, hasDestructiveChange: true };
       if (rawMeta) {
         try {
@@ -1811,7 +1832,10 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
             updatedAt: parsed?.updatedAt ?? 0,
           };
         } catch (e) {
-          logger.warn("invalid whiteboard meta json on sync", { roomId, err: e?.message });
+          logger.warn("invalid whiteboard meta json on sync", {
+            roomId, materialId: normalizedMaterialId, pageNumber: normalizedPageNumber,
+            err: e?.message,
+          });
         }
       }
 
@@ -1833,11 +1857,12 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
         strokes: payloadStrokes.map(normalizeStroke),
         mode,
         serverTick: meta.serverTick,
+        materialId: normalizedMaterialId,
+        pageNumber: normalizedPageNumber,
       });
 
       logger.info("sync:state sent", {
-        roomId,
-        mode,
+        roomId, materialId: normalizedMaterialId, pageNumber: normalizedPageNumber, mode,
         total: strokes.length,
         delta: payloadStrokes.length,
         clientLastTick,
@@ -1846,7 +1871,12 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
         redisMiss: rawBoard === null,
       });
     } catch (err) {
-      logger.error("sync:state failed", { err: err?.message });
+      logger.error("sync:state failed", {
+        roomId,
+        materialId: normalizedMaterialId,
+        pageNumber: normalizedPageNumber,
+        err: err?.message,
+      });
       socket.emit(SOCKET_EVENTS.ERROR, {
         code: ERRORS.INTERNAL_ERROR,
         message: "SYNC_FAILED",


### PR DESCRIPTION
## 🛠 Issue

페이지 단위 판서 sync 요청 및 복원 기능 구현

기존에는 세션 단위로 모든 판서 데이터를 함께 관리하여,
특정 페이지 복원 시 불필요한 데이터 전송과 복원 비용이 발생했다.

이를 해결하기 위해 판서 상태를 페이지 단위로 분리하여
보다 정확하고 효율적인 복원을 지원한다.

---

## 📝 To-do

* [x] sync:request에 materialId, pageNumber 파라미터 추가
* [x] Redis key를 페이지 단위 구조로 변경
* [x] sync:state에서 해당 페이지 strokes만 반환하도록 수정
* [x] lastTick 기반 delta 복원 로직을 페이지 단위로 적용
* [x] 전체 복원(full sync) fallback 동작 유지 및 검증

---

## 📌 변경사항

* whiteboard:{sessionId} → whiteboard:{sessionId}:{materialId}:{pageNumber}
* 페이지 단위로 판서 상태 분리 및 복원 처리
* sync:request 파라미터에 materialId, pageNumber 추가
* sync:state 응답에 materialId, pageNumber 포함 (응답 식별 가능)
* lastTick 기반 delta/full sync 로직 유지
* pageWbKey/pageMetaKey에 encodeURIComponent 적용
  (materialId에 특수문자 포함 시 Redis key 구조 깨짐 방지)
* materialId trim 및 pageNumber Number() 변환으로 입력값 정규화
* lastTick null/undefined 명시 처리로 잘못된 delta 트리거 방지
* warn/error 로그에 materialId, pageNumber 추가

---

## ⚠️ 주의

* sync:request 파라미터 구조가 변경되므로 프론트와 동시 배포 필요
* 기존 session-level Redis 데이터와 호환되지 않음 (새 구조로 저장됨)

---

## ✅ 테스트 체크리스트

* [ ] 특정 페이지 요청 시 해당 페이지 데이터만 반환되는지 확인
* [ ] lastTick 기반 delta sync 정상 동작 확인
* [ ] destructive change 이후 full sync 동작 확인
* [ ] Redis miss 시 정상적으로 full sync 수행되는지 확인
