### PR TITLE
[Fix]: #117 - 페이지 단위 판서 구조 반영 및 /materials 조회 필드명 오류 수정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ NODE_ENV=development
 JWT_SECRET=dev-secret-change-me
 SESSION_TTL_SECONDS=21600
 
+DATABASE_URL=postgresql://user:password@localhost:5432/pentalk_dev
+REDIS_URL=redis://localhost:6379
+
 AWS_REGION=ap-northeast-2
 S3_BUCKET_NAME=pentalk-storage
 

--- a/src/server.js
+++ b/src/server.js
@@ -1020,7 +1020,7 @@ app.get("/materials", requireAuth, requireClassMember, async (req, res) => {
 
     // subject 필터: MaterialSubject 조인 테이블을 통해 필터링
     if (subjectId) {
-      where.subjects = {
+      where.MaterialSubject = {
         some: { subjectId },
       };
     }
@@ -1046,9 +1046,9 @@ app.get("/materials", requireAuth, requireClassMember, async (req, res) => {
       where,
       orderBy: { createdAt: "desc" },
       include: {
-        subjects: {
+        MaterialSubject: {
           include: {
-            subject: { select: { id: true, name: true } },
+            Subject: { select: { id: true, name: true } },
           },
         },
         MaterialTag: {
@@ -1067,9 +1067,9 @@ app.get("/materials", requireAuth, requireClassMember, async (req, res) => {
       url: m.url,
       classId: m.classId,
       createdAt: m.createdAt,
-      subjects: (m.subjects || []).map((ms) => ({
-        id: ms.subject.id,
-        name: ms.subject.name,
+      subjects: (m.MaterialSubject || []).map((ms) => ({
+        id: ms.Subject.id,
+        name: ms.Subject.name,
       })),
       tags: (m.MaterialTag || []).map((mt) => ({
         id: mt.Tag.id,


### PR DESCRIPTION
## 🛠 변경 사항
- 페이지 단위 판서 구조(#111/#112/#113) 반영
- Redis 및 관련 로직에서 page 기준 데이터 처리 적용
- GET /materials 조회 시 필드명 오류 수정 (subjects → MaterialSubject)

## 📌 참고
세션 종료 및 export 관련 일부 로직은 session-level key를 사용 중이며,
해당 부분은 이후 이슈에서 page-level 기준으로 정리 예정입니다.