### PR TITLE
[Feat]: #118 - presigned URL 발급 API 추가

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1099,6 +1099,31 @@ app.get("/materials", requireAuth, requireClassMember, async (req, res) => {
 
 
 
+app.get("/materials/:materialId/download-url", requireAuth, async (req, res) => {
+  const { materialId } = req.params;
+  try {
+    const material = await prisma.material.findUnique({
+      where: { id: materialId },
+      select: { url: true, classId: true },
+    });
+    if (!material) {
+      return sendHttpError(res, 404, ERRORS.MATERIAL_NOT_FOUND, "MATERIAL_NOT_FOUND");
+    }
+    const membership = await prisma.classMember.findFirst({
+      where: { classId: material.classId, userId: req.userId },
+      select: { id: true },
+    });
+    if (!membership) {
+      return sendHttpError(res, 403, ERRORS.FORBIDDEN, "NOT_CLASS_MEMBER");
+    }
+    const url = await getPresignedUrl(material.url);
+    return res.json({ url });
+  } catch (err) {
+    logger.error("download-url failed", { materialId, err: err?.message });
+    return sendHttpError(res, 500, ERRORS.INTERNAL_ERROR, "DOWNLOAD_URL_FAILED");
+  }
+});
+
 app.post("/materials/:materialId/subjects", async (req, res) => {
   const { materialId } = req.params;
   const { subjectIds } = req.body;


### PR DESCRIPTION
## 🛠 변경 사항
- materialId를 기반으로 presigned URL을 발급하는 API 추가
- GET /materials/:materialId/download-url 엔드포인트 구현
- 클래스 멤버 여부를 검증하여 접근 제어 적용

## 📌 배경
기존 GET /materials 응답의 url 필드는 S3 key로,
프론트에서 직접 접근이 불가능한 상태였습니다.

이를 해결하기 위해 실제 접근 가능한 presigned URL을
발급하는 API를 추가했습니다.

## ✅ 테스트
- [ ] 정상적으로 presigned URL이 발급되는지 확인
- [ ] 권한 없는 사용자는 접근이 차단되는지 확인