### PR TITLE
feat: 세션 생성 응답에 학생 입장 joinUrl 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,3 @@ REDIS_URL=redis://localhost:6379
 
 AWS_REGION=ap-northeast-2
 S3_BUCKET_NAME=pentalk-storage
-
-# 로컬/Docker 전용. EC2는 IAM Role 사용 시 불필요.
-AWS_ACCESS_KEY_ID=your_access_key
-AWS_SECRET_ACCESS_KEY=your_secret_key

--- a/src/server.js
+++ b/src/server.js
@@ -1663,15 +1663,13 @@ if (
 
 logger.info("session created", { sessionId, classId: sessionData.classId });
 
-const clientOrigin =
-  process.env.CLIENT_ORIGIN || APP_CONFIG.CORS_ORIGIN || "http://localhost:5173";
+const frontendBaseUrl = process.env.CLIENT_ORIGIN || "http://localhost:5173";
 const ttlSeconds = Number(process.env.SESSION_TTL_SECONDS || 21600);
 
 res.json({
   sessionId,
   materialId: sessionData.materialId,
-  joinUrlTeacher: `${clientOrigin}/?sessionId=${sessionId}&role=teacher`,
-  joinUrlStudent: `${clientOrigin}/?sessionId=${sessionId}&role=student`,
+  joinUrl: `${frontendBaseUrl}/join/${sessionId}`,
   ttlSeconds,
 });
 });


### PR DESCRIPTION
세션 생성 응답 구조를 학생 입장용 단일 joinUrl 기반으로 정리했습니다.

기존의 joinUrlTeacher / joinUrlStudent 필드를 제거하고,
프론트엔드 QR 코드 생성에 사용되는 학생 입장용 joinUrl만 제공하도록 변경했습니다.

또한 URL 생성 기준을 CLIENT_ORIGIN으로 명확히 하여,
CORS_ORIGIN이 *인 경우 발생할 수 있는 잘못된 URL 생성 문제를 방지했습니다.