### PR TITLE
feat: 세션 종료 후 복습 퀴즈 HTTP 조회 및 제출 구현

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -8,8 +8,10 @@ const ROUTES = {
   MATERIAL_UPLOAD: '/materials/pdf',  // ✅ #93
 
   // ✅ #60
-  QUIZ_BASE: '/sessions/:sessionId/quiz',             // GET(목록), POST(추가)
-  QUIZ_ITEM: '/sessions/:sessionId/quiz/:questionId', // PUT(수정), DELETE(삭제)
+  QUIZ_BASE:   '/sessions/:sessionId/quiz',                  // GET(목록), POST(추가)
+  QUIZ_ITEM:   '/sessions/:sessionId/quiz/:questionId',      // PUT(수정), DELETE(삭제)
+  // ✅ #132
+  QUIZ_SUBMIT: '/sessions/:sessionId/quiz/submit',           // POST(복습 퀴즈 제출, 학생 전용)
 };
 
 module.exports = { ROUTES };

--- a/src/server.js
+++ b/src/server.js
@@ -1757,10 +1757,14 @@ app.post(ROUTES.SESSION_JOIN, async (req, res) => {
 
 // ✅ #60: 퀴즈 문항 관리 REST API
 
-app.get(ROUTES.QUIZ_BASE, requireAuth, requireTeacherRole, async (req, res) => {
+app.get(ROUTES.QUIZ_BASE, requireAuth, async (req, res) => {
   const { sessionId } = req.params;
   try {
-    const session = await sessionStore.get(sessionId);
+    // Redis 세션 객체에 status 필드가 없으므로 DB에서 직접 조회
+    const session = await prisma.session.findUnique({
+      where: { id: sessionId },
+      select: { classId: true, status: true },
+    });
     if (!session) return sendHttpError(res, 404, ERRORS.SESSION_NOT_FOUND, 'SESSION_NOT_FOUND');
 
     const membership = await prisma.classMember.findFirst({
@@ -1769,18 +1773,29 @@ app.get(ROUTES.QUIZ_BASE, requireAuth, requireTeacherRole, async (req, res) => {
     });
     if (!membership) return sendHttpError(res, 403, ERRORS.FORBIDDEN, 'NOT_CLASS_MEMBER');
 
+    if (!['teacher', 'student'].includes(req.role))
+      return sendHttpError(res, 403, ERRORS.FORBIDDEN, 'INVALID_ROLE');
+
+    // 학생은 ARCHIVED 세션만 조회 가능 (수업 중 문항 노출 방지)
+    if (req.role === 'student' && session.status !== 'ARCHIVED')
+      return sendHttpError(res, 403, ERRORS.FORBIDDEN, 'SESSION_NOT_ENDED');
+
+    const isTeacher = req.role === 'teacher';
+
     const questions = await prisma.quizQuestion.findMany({
       where: { sessionId },
       orderBy: { order: 'asc' },
-      select: { id: true, question: true, answer: true, order: true, createdAt: true },
+      select: isTeacher
+        ? { id: true, question: true, answer: true, order: true, createdAt: true }
+        : { id: true, question: true, order: true, createdAt: true },
     });
 
-    const active = activeQuizzes.get(sessionId) ?? null;
+    const active = isTeacher ? (activeQuizzes.get(sessionId) ?? null) : undefined;
 
     return res.json({
       ok: true,
       questions,
-      activeQuestionId: active?.questionId ?? null,
+      ...(isTeacher && { activeQuestionId: active?.questionId ?? null }),
     });
   } catch (e) {
     logger.error('quiz list error', { sessionId, err: e?.message });
@@ -1952,6 +1967,117 @@ app.delete(ROUTES.QUIZ_ITEM, requireAuth, requireTeacherRole, async (req, res) =
   } catch (e) {
     logger.error('quiz delete error', { sessionId, questionId, err: e?.message });
     return sendHttpError(res, 500, ERRORS.INTERNAL_ERROR, 'QUIZ_DELETE_FAILED');
+  }
+});
+
+// ✅ #132: 복습 퀴즈 HTTP 제출 (학생 전용, ARCHIVED 세션)
+app.post(ROUTES.QUIZ_SUBMIT, requireAuth, async (req, res) => {
+  const { sessionId } = req.params;
+  const { questionId, answer } = req.body;
+  const userId = req.userId;
+
+  // 1. 학생 전용
+  if (req.role !== 'student')
+    return sendHttpError(res, 403, ERRORS.FORBIDDEN, 'STUDENTS_ONLY');
+
+  // 2. 입력 검증
+  if (typeof questionId !== 'string' || !questionId.trim())
+    return sendHttpError(res, 400, ERRORS.PAYLOAD_INVALID, 'questionId 누락');
+  const trimmedAnswer = typeof answer === 'string' ? answer.trim() : '';
+  if (!trimmedAnswer)
+    return sendHttpError(res, 400, ERRORS.PAYLOAD_INVALID, 'answer 누락');
+  if (trimmedAnswer.length > MAX_QUIZ_ANSWER_LENGTH)
+    return sendHttpError(res, 400, ERRORS.PAYLOAD_INVALID, `최대 ${MAX_QUIZ_ANSWER_LENGTH}자`);
+
+  const trimmedQId = questionId.trim();
+
+  try {
+    // 3. 세션 확인 — ARCHIVED만 허용
+    const dbSession = await prisma.session.findUnique({
+      where: { id: sessionId },
+      select: { classId: true, status: true },
+    });
+    if (!dbSession) return sendHttpError(res, 404, ERRORS.SESSION_NOT_FOUND, 'SESSION_NOT_FOUND');
+    if (dbSession.status !== 'ARCHIVED')
+      return sendHttpError(res, 400, ERRORS.PAYLOAD_INVALID, 'SESSION_NOT_ENDED');
+
+    // 4. classMember 검증
+    const membership = await prisma.classMember.findFirst({
+      where: { classId: dbSession.classId, userId },
+      select: { id: true },
+    });
+    if (!membership) return sendHttpError(res, 403, ERRORS.FORBIDDEN, 'NOT_CLASS_MEMBER');
+
+    // 5. 일일 응시 횟수 검증 — INCR 선행으로 경쟁 조건 방지 (소켓과 동일 정책)
+    const dailyKey = `quiz:count:${userId}:${getKSTDateString()}`;
+    try {
+      const count = await redis.incr(dailyKey);
+      if (count === 1) await redis.expire(dailyKey, getSecondsUntilMidnightKST());
+      if (count > MAX_QUIZ_DAILY_ATTEMPTS)
+        return sendHttpError(res, 429, ERRORS.QUIZ_DAILY_LIMIT_EXCEEDED, `하루 최대 ${MAX_QUIZ_DAILY_ATTEMPTS}회까지 응시할 수 있습니다`);
+    } catch (e) {
+      logger.warn('quiz daily count check failed, allowing submission', { userId, err: e?.message });
+    }
+
+    // 6. 문항 조회 + 채점
+    let correctAnswer;
+    try {
+      const q = await prisma.quizQuestion.findFirst({
+        where: { id: trimmedQId, sessionId },
+        select: { answer: true },
+      });
+      if (!q) return sendHttpError(res, 404, ERRORS.QUIZ_NOT_FOUND, '문항을 찾을 수 없습니다');
+      correctAnswer = q.answer;
+    } catch (e) {
+      logger.error('quiz submit fetch failed', { sessionId, questionId: trimmedQId, err: e?.message });
+      return sendHttpError(res, 500, ERRORS.QUIZ_SUBMIT_FAILED, '채점 실패');
+    }
+
+    const normalizedCorrectAnswer = String(correctAnswer).trim();
+    const isCorrect = trimmedAnswer === normalizedCorrectAnswer;
+
+    // 7. DB 저장 — 최대 1회 재시도, P2002 중복키 처리 (소켓과 동일)
+    for (let attempt = 1; attempt <= 2; attempt++) {
+      try {
+        await prisma.quizAnswer.create({
+          data: { sessionId, questionId: trimmedQId, userId, submittedAnswer: trimmedAnswer, isCorrect },
+        });
+        break;
+      } catch (e) {
+        if (e?.code === 'P2002') {
+          const existing = await prisma.quizAnswer.findUnique({
+            where: { sessionId_questionId_userId: { sessionId, questionId: trimmedQId, userId } },
+            select: { submittedAnswer: true, isCorrect: true },
+          });
+          if (!existing)
+            return sendHttpError(res, 500, ERRORS.QUIZ_SUBMIT_FAILED, '기존 제출 조회 실패');
+          return res.json({
+            ok: true,
+            questionId: trimmedQId,
+            isCorrect: existing.isCorrect,
+            submittedAnswer: existing.submittedAnswer,
+            correctAnswer: normalizedCorrectAnswer,
+          });
+        }
+        if (attempt === 2) {
+          logger.error('quiz submit save failed', { sessionId, questionId: trimmedQId, userId, err: e?.message });
+          return sendHttpError(res, 500, ERRORS.QUIZ_SUBMIT_FAILED, '저장 실패');
+        }
+      }
+    }
+
+    logger.info('📝 quiz http submitted', { sessionId, questionId: trimmedQId, userId, isCorrect });
+
+    return res.json({
+      ok: true,
+      questionId: trimmedQId,
+      isCorrect,
+      submittedAnswer: trimmedAnswer,
+      correctAnswer: normalizedCorrectAnswer,
+    });
+  } catch (e) {
+    logger.error('quiz http submit error', { sessionId, userId, err: e?.message });
+    return sendHttpError(res, 500, ERRORS.QUIZ_SUBMIT_FAILED, '제출 실패');
   }
 });
 


### PR DESCRIPTION
## 🛠 Issue

세션 종료 후 학생이 복습 퀴즈를 조회·제출할 수 있도록
HTTP 기반 복습 퀴즈 기능을 추가했습니다.

기존 GET /sessions/:sessionId/quiz는 교사 전용이었으며,
퀴즈 제출 기능도 소켓 기반으로만 존재했습니다.

프론트엔드 구조 변경에 따라,
세션 종료 후에는 HTTP 기반으로 복습 퀴즈를 처리할 수 있도록 백엔드를 확장했습니다.

---

## ✨ Changes

* GET /sessions/:sessionId/quiz 학생 접근 허용

  * requireTeacherRole 제거
  * classMember 기반 권한 검증으로 변경

* 학생 응답에서 answer 필드 제외

  * 학생은 정답 없이 문항만 조회 가능
  * 교사만 answer 및 activeQuestionId 응답 유지

* POST /sessions/:sessionId/quiz/submit 신규 추가

  * 학생 전용 HTTP 제출 엔드포인트 구현
  * ARCHIVED 세션에서만 제출 가능

* 세션 조회 방식 수정

  * Redis sessionStore 대신 DB 기준 조회
  * ARCHIVED 세션 status 검증 지원

* 기존 소켓 제출 정책 유지

  * Redis INCR 기반 일일 제출 제한
  * Prisma P2002 중복 제출 처리
  * 최대 1회 재시도 정책 유지

* role 방어 로직 추가

  * teacher / student 외 role 차단
  * 학생 외 HTTP 제출 차단

---

## 📌 Notes

* 학생은 ARCHIVED 세션에서만 복습 퀴즈 조회·제출이 가능합니다.
* 복습 퀴즈 특성상 제출 후 correctAnswer 응답을 유지했습니다.
* Redis 세션 객체에는 status 필드가 없어 세션 상태 판단은 DB 기준으로 처리했습니다.
* 일일 제출 제한은 기존 소켓 구현과 동일하게 Redis INCR 선행 정책을 유지했습니다.
* express.json()은 전역 등록(app.use(express.json()))이 이미 존재하여 라우트별 중복 등록을 제거했습니다.

---

## ✅ Test Checklist

* [ ] 학생이 ARCHIVED 세션 GET 조회 시 answer 없이 응답되는지 확인
* [ ] 교사가 GET 조회 시 answer 및 activeQuestionId 포함 응답되는지 확인
* [ ] 학생이 ACTIVE 세션 GET 조회 시 403 반환 확인
* [ ] 학생이 ARCHIVED 세션 POST 제출 시 채점 및 저장 성공 확인
* [ ] 교사가 POST 제출 시 403 반환 확인
* [ ] 중복 제출 시 기존 제출 결과 반환 확인
* [ ] 일일 제출 제한 초과 시 429 반환 확인
* [ ] node --check 통과 확인
