### PR TITLE
[Feat] 퀴즈 통과 여부 조회 API 추가

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -12,6 +12,8 @@ const ROUTES = {
   QUIZ_ITEM:   '/sessions/:sessionId/quiz/:questionId',      // PUT(수정), DELETE(삭제)
   // ✅ #132
   QUIZ_SUBMIT: '/sessions/:sessionId/quiz/submit',           // POST(복습 퀴즈 제출, 학생 전용)
+  // ✅ #134
+  QUIZ_RESULT: '/sessions/:sessionId/quiz/result',           // GET(퀴즈 통과 여부 조회)
 };
 
 module.exports = { ROUTES };

--- a/src/server.js
+++ b/src/server.js
@@ -2081,6 +2081,54 @@ app.post(ROUTES.QUIZ_SUBMIT, requireAuth, async (req, res) => {
   }
 });
 
+// ✅ #134: 퀴즈 통과 여부 조회
+app.get(ROUTES.QUIZ_RESULT, requireAuth, async (req, res) => {
+  const { sessionId } = req.params;
+  const userId = req.userId;
+
+  try {
+    // 1. 세션 확인 (DB 기준)
+    const session = await prisma.session.findUnique({
+      where: { id: sessionId },
+      select: { classId: true, status: true },
+    });
+    if (!session) return sendHttpError(res, 404, ERRORS.SESSION_NOT_FOUND, 'SESSION_NOT_FOUND');
+
+    // 2. classMember 검증
+    const membership = await prisma.classMember.findFirst({
+      where: { classId: session.classId, userId },
+      select: { id: true },
+    });
+    if (!membership) return sendHttpError(res, 403, ERRORS.FORBIDDEN, 'NOT_CLASS_MEMBER');
+
+    // 3. role 검증
+    if (!['teacher', 'student'].includes(req.role))
+      return sendHttpError(res, 403, ERRORS.FORBIDDEN, 'INVALID_ROLE');
+
+    // 4. 교사는 항상 통과
+    if (req.role === 'teacher')
+      return res.json({ ok: true, passed: true, correctCount: null });
+
+    // 5. ARCHIVED 이전 상태(ACTIVE·CLOSING·FAILED)에서는 퀴즈 제한 미적용
+    if (session.status !== 'ARCHIVED')
+      return res.json({ ok: true, passed: true, correctCount: null });
+
+    // 6. 정답 개수 조회 및 통과 여부 계산
+    const correctCount = await prisma.quizAnswer.count({
+      where: { sessionId, userId, isCorrect: true },
+    });
+
+    return res.json({
+      ok: true,
+      passed: correctCount >= 2,
+      correctCount,
+    });
+  } catch (e) {
+    logger.error('quiz result error', { sessionId, userId, err: e?.message });
+    return sendHttpError(res, 500, ERRORS.INTERNAL_ERROR, 'QUIZ_RESULT_FAILED');
+  }
+});
+
 // ✅ #93: multer 에러 핸들러
 // Express 에러 핸들러는 라우트들 뒤, io.on('connection') 앞에 위치해야 함.
 app.use((err, req, res, next) => {


### PR DESCRIPTION
## 🛠 Issue

수업 종료 이후 학생은 복습 퀴즈를 통과해야만 개인 필기 및 PDF export 기능을 사용할 수 있다.

현재는 퀴즈 제출 직후 응답에서만 통과 여부를 알 수 있어,
앱 재접속·세션 재진입 시 프론트엔드가 기능 활성화 여부를 판단할 수 없다.

따라서 세션 진입 시마다 학생의 퀴즈 통과 여부를 조회할 수 있는 API가 필요하다.

---

## ✨ Changes

* 퀴즈 통과 여부 조회 API 추가
  * `GET /sessions/:sessionId/quiz/result`

* 학생별 퀴즈 결과 조회 로직 구현
  * 현재 세션 기준 정답 개수 조회
  * `isCorrect: true` 조건으로 count

* 퀴즈 통과 여부 계산 로직 추가
  * `correctCount >= 2`

* 세션 참여 여부 검증 추가
  * 세션 참여 학생만 결과 조회 가능

* 교사 역할 예외 처리 추가
  * 교사는 항상 `passed: true` 반환

* ARCHIVED 이전 상태 예외 처리 추가
  * ACTIVE·CLOSING·FAILED 상태에서는 퀴즈 제한 미적용
  * 정상 응답(`passed: true`) 반환

---

## 📌 Notes

* 프론트엔드는 세션 진입 시 해당 API를 호출하여:
  * 개인 필기 기능 활성화 여부
  * PDF export 가능 여부
  를 판단한다.

* 퀴즈 제출 직후뿐 아니라 앱 재실행·재접속 상황도 고려한 API이다.

* 교사는 기존 정책과 동일하게 퀴즈 검증 없이 항상 `passed: true`를 반환한다.