### PR TITLE
fix: Redis 데이터 영속성 설정 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
     restart: always
     ports:
       - "6379:6379"
+    volumes:
+      - redis_data:/data
+    command: redis-server --appendonly yes
 
   postgres:
     image: postgres:16
@@ -40,3 +43,4 @@ services:
 volumes:
   postgres_data:
   whiteboard_data:
+  redis_data:


### PR DESCRIPTION
## 🛠 Issue

현재 Redis 컨테이너에는 volume 설정이 없어 Docker 재빌드 또는 컨테이너 재생성 시 Redis 데이터가 모두 초기화되고 있었습니다.

이로 인해 세션 정보 및 materialId 등의 런타임 데이터가 유실되는 문제가 발생했습니다.

반면 PostgreSQL은 postgres_data volume을 사용하고 있어 데이터가 유지되고 있으며, Redis만 persistence 구성이 누락된 상태였습니다.

이번 작업에서는 Redis 데이터 영속성을 위해 volume 및 appendonly(AOF) 설정을 추가했습니다.

---

## ✨ Changes

- docker-compose.yml에 Redis volume(redis_data) 추가
- Redis /data 디렉터리 volume mount 적용
- redis-server --appendonly yes 설정 추가
- Docker 재빌드 이후에도 Redis 세션 데이터 유지 가능하도록 수정

---

## 📌 Notes

- 기존 Redis 데이터는 컨테이너 재생성 시 초기화될 수 있음
- AOF(Append Only File) 기반 persistence 사용
- PostgreSQL과 동일하게 Docker volume 기반 데이터 보존 구조 적용