### PR TITLE
fix: 학생 세션 입장 시 materialId 누락 수정

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -2419,6 +2419,7 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
     socket.emit(SOCKET_EVENTS.JOIN_SUCCESS, {
       roomId,
       classId: session.classId,
+      materialId: session.materialId ?? null,
       user: { userId: socket.data.userId, role: socket.data.role }
     });
 


### PR DESCRIPTION
## 🛠 Issue

학생이 QR 링크를 통해 세션에 입장할 때,
서버의 `JOIN_SUCCESS` 응답에 현재 세션의 `materialId`가 포함되지 않아
학생 클라이언트가 현재 수업 자료를 즉시 불러오지 못하는 문제가 발생했습니다.

이로 인해 교사가 이미 자료를 등록하고 드로잉 모드에 진입한 상태여도,
학생 화면에서는 자료가 보이지 않거나 새로고침 이후에만 반영되는 현상이 발생했습니다.

이번 작업에서는 학생 입장 시 현재 활성 자료 정보를 함께 전달하도록 수정합니다.

---

## ✨ Changes

- `JOIN_SUCCESS` 응답 payload에 `materialId` 추가
- 학생 입장 직후 현재 세션 자료를 즉시 로드할 수 있도록 수정
- 교사가 이미 드로잉 모드인 상태에서도 학생 화면 동기화 가능하도록 개선
- 기존 세션 상태 전달 구조와 일관성 유지

---

## 📌 Notes

- 기존에는 학생이 입장 후 별도 이벤트를 기다려야만 자료를 인식할 수 있었음
- 현재 활성 자료(material)가 없는 경우 `materialId`는 `null` 가능
- 실기기 환경(QR 입장 시나리오)에서 재현된 문제 기준으로 수정 진행