### PR TITLE
[Fix]: #145- 학생 세션 입장 시 현재 자료 정보 전달

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -2416,10 +2416,21 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
       teachersRoom,
     });
 
+    const materialId = session.materialId ?? null;
+
+    let material = null;
+    if (materialId) {
+      material = await prisma.material.findUnique({
+        where: { id: materialId },
+        select: { id: true, name: true, type: true, url: true },
+      });
+    }
+
     socket.emit(SOCKET_EVENTS.JOIN_SUCCESS, {
       roomId,
       classId: session.classId,
-      materialId: session.materialId ?? null,
+      materialId: material?.id ?? materialId,
+      material,
       user: { userId: socket.data.userId, role: socket.data.role }
     });
 


### PR DESCRIPTION
## 🛠 Issue

학생이 QR 링크를 통해 세션에 입장한 뒤 현재 자료를 렌더링하기 위해 `/materials?classId=...` API를 호출하고 있었습니다.

하지만 해당 API는 클래스 멤버 권한을 요구하기 때문에, 세션에는 join 성공했지만 class member가 아닌 학생은 `403 NOT_CLASS_MEMBER` 에러가 발생했습니다.

현재 `JOIN_SUCCESS` 응답에는 `materialId`만 포함되어 있어 프론트엔드가 추가 API 호출을 해야 하는 구조였습니다.

이번 작업에서는 학생 입장 성공 시 현재 세션의 자료 정보를 함께 전달하여, 별도의 class materials API 호출 없이 즉시 자료를 렌더링할 수 있도록 수정했습니다.

---

## ✨ Changes

- `JOIN_SUCCESS` 응답 payload에 `material` 객체 추가
- `session.materialId` 존재 시 Material 조회 로직 추가
- 응답에 `id`, `name`, `type`, `url` 포함
- 활성 자료가 없는 경우 `material: null` 반환
- 기존 `materialId` 필드는 유지
- `/materials?classId=...` 권한 모델은 변경하지 않도록 유지

---

## 📌 Notes

- QR 세션 입장과 클래스 멤버 권한은 별도 개념으로 유지됩니다.
- 학생을 classMember로 자동 등록하지 않습니다.
- `url` 필드는 S3 key 형태이며 직접 접근 가능한 public URL은 아닙니다.
- `JOIN_SUCCESS` 응답에 material 객체를 포함함으로써, QR 입장 학생이 class materials API를 호출하지 않고도 즉시 현재 자료를 렌더링할 수 있습니다.