### PR TITLE
[Fix]: #147- materialId 변수명 충돌 수정

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -2416,12 +2416,12 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
       teachersRoom,
     });
 
-    const materialId = session.materialId ?? null;
+    const sessionMaterialId = session.materialId ?? null;
 
     let material = null;
-    if (materialId) {
+    if (sessionMaterialId) {
       material = await prisma.material.findUnique({
-        where: { id: materialId },
+        where: { id: sessionMaterialId },
         select: { id: true, name: true, type: true, url: true },
       });
     }
@@ -2429,7 +2429,7 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
     socket.emit(SOCKET_EVENTS.JOIN_SUCCESS, {
       roomId,
       classId: session.classId,
-      materialId: material?.id ?? materialId,
+      materialId: material?.id ?? sessionMaterialId,
       material,
       user: { userId: socket.data.userId, role: socket.data.role }
     });


### PR DESCRIPTION
## 🛠 Issue

학생 세션 입장 처리 과정에서 `materialId` 변수명이 중복 선언되어
서버가 크래시되는 문제가 발생했습니다.

기존 함수 파라미터 `materialId`와 동일한 이름의 지역 변수를 다시 선언하면서
JOIN_SUCCESS 응답 생성 과정에서 충돌이 발생했습니다.

## ✨ Changes

- 세션 materialId 지역 변수명을 `sessionMaterialId`로 변경
- material 조회 로직에서 변경된 변수명 적용
- JOIN_SUCCESS 응답의 materialId 반환 로직 수정
- 변수명 충돌로 인한 서버 크래시 문제 해결

## 📌 Notes

- 기존 동작 로직은 유지하고 변수명 충돌만 수정했습니다.
- 세션에 materialId가 없는 경우 기존처럼 null 처리됩니다.