### PR TITLE
[Fix]: #149-세션 materialId Redis 동기화 처리

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -2271,6 +2271,15 @@ app.post(
       });
 
       logger.info('session material uploaded', { sessionId, materialId: material.id });
+
+      const updatedSession = await sessionStore.update(sessionId, { materialId: material.id });
+
+      if (updatedSession) {
+        logger.info('redis session materialId synced', { sessionId, materialId: material.id });
+      } else {
+        logger.warn('redis session not found while syncing materialId', { sessionId, materialId: material.id });
+      }
+
       return res.status(201).json({ ok: true, material });
     } catch (err) {
       if (err.code === 'MATERIAL_ALREADY_SET')

--- a/src/store/sessionStore.js
+++ b/src/store/sessionStore.js
@@ -35,6 +35,24 @@ module.exports = {
     return result === 1;
   },
 
+  async update(sessionId, patch) {
+    const key = makeKey(sessionId);
+    const current = await this.get(sessionId);
+
+    if (!current) return null;
+
+    const ttl = await redis.ttl(key);
+    const updated = { ...current, ...patch };
+
+    await redis.setex(
+      key,
+      ttl > 0 ? ttl : APP_CONFIG.SESSION_TTL_SECONDS,
+      JSON.stringify(updated)
+    );
+
+    return updated;
+  },
+
   async delete(sessionId) {
     const key = makeKey(sessionId);
     await redis.del(key);


### PR DESCRIPTION
🛠 Issue

현재 자료 업로드 시 DB(Session.materialId)에는 정상적으로 materialId가 저장되지만, Redis sessionStore에는 해당 값이 갱신되지 않아 학생 입장 시 materialId: null 상태로 전달되는 문제가 발생했습니다.

이로 인해 학생 클라이언트에서는 세션 자체는 인식하지만 현재 활성 자료를 불러오지 못하고 빈 자료 목록으로 처리되고 있었습니다.

이번 작업에서는 자료 업로드 이후 Redis 세션 데이터도 함께 갱신되도록 수정하여, 학생 입장 직후 최신 materialId를 정상적으로 전달할 수 있도록 개선했습니다.

✨ Changes
sessionStore에 update 메서드 추가
Redis 세션 데이터 부분 갱신 기능 구현
기존 TTL 유지 기반 Redis setex 처리 추가
자료 업로드 성공 후 Redis 세션 materialId 동기화 로직 추가
Redis 동기화 성공/실패 로그 분리 추가
학생 JOIN_SUCCESS 응답 시 최신 materialId 전달 가능하도록 수정
📌 Notes
기존에는 DB만 업데이트되고 Redis 세션 캐시는 갱신되지 않았음
학생 입장 시 세션 정보는 Redis 기준으로 조회되고 있었음
Redis 세션이 없는 경우 update는 null을 반환하며 warn 로그만 남기고 기존 흐름은 유지함
권한 모델 및 기존 세션 로직은 변경하지 않음