### PR TITLE
[Feat]: #151- materials 업로드 시 session materialId 동기화

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1077,6 +1077,8 @@ app.post(
       return sendHttpError(res, 400, ERRORS.PAYLOAD_INVALID, 'CLASS_ID_REQUIRED');
     }
 
+    const sessionId = (req.body.sessionId || '').toString().trim() || null;
+
     // classId 검증부터 prisma.create까지 하나의 try로 묶음.
     // findUnique 포함 DB 접근에서 예외가 나도 cleanup이 보장됨.
     try {
@@ -1104,6 +1106,17 @@ app.post(
       });
 
       logger.info('material uploaded', { materialId: material.id, classId });
+
+      if (sessionId) {
+        const updatedSession = await sessionStore.update(sessionId, { materialId: material.id });
+
+        if (updatedSession) {
+          logger.info('redis session materialId synced', { sessionId, materialId: material.id });
+        } else {
+          logger.warn('redis session not found while syncing materialId', { sessionId, materialId: material.id });
+        }
+      }
+
       return res.status(201).json(material);
     } catch (err) {
       logger.error('material upload failed', { err });


### PR DESCRIPTION
🛠 Issue

현재 프론트엔드는 자료 업로드 시 POST /materials API를 사용하고 있습니다.

하지만 기존 구현에서는 Material DB 생성만 수행하고,
Redis 기반 active session의 materialId는 갱신하지 않아
학생 입장 시 material: null 상태가 전달되는 문제가 발생했습니다.

이번 작업에서는 POST /materials 요청에 sessionId를 함께 받아,
자료 업로드 직후 Redis session의 materialId를 동기화하도록 수정했습니다.

✨ Changes
POST /materials 요청에 sessionId 필드 지원 추가
Material 생성 후 Redis session의 materialId 동기화 로직 추가
학생 입장 시 현재 활성 자료 정보가 즉시 전달되도록 수정
Redis session 미존재 시 warning 로그 추가
📝 To-do
<!-- 진행할 작업에 대해 적어주세요 -->
 POST /materials 요청에 sessionId 필드 지원 추가
 Material 생성 후 Redis session의 materialId 동기화 로직 구현
 학생 입장 시 현재 material 정보 정상 전달되는지 검증
📌 Notes
sessionId가 전달된 경우에만 Redis session 동기화를 수행합니다.
기존 POST /materials 업로드 플로우와의 하위 호환성을 유지합니다.
Redis active session이 없는 경우 Material 생성 자체는 정상 처리됩니다.