### PR TITLE
[Fix]: #153-HTTP join 응답에 material 정보 추가

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1830,12 +1830,32 @@ app.post(ROUTES.SESSION_JOIN, async (req, res) => {
     return sendHttpError(res, 409, ERRORS.SESSION_CAPACITY_EXCEEDED, "SESSION_CAPACITY_EXCEEDED");
   }
 
-  // 6. 입장 허가 응답
+  // 6. material 조회 및 presigned URL 생성
+  let material = null;
+  const sessionMaterialId = session.materialId ?? null;
+  if (sessionMaterialId) {
+    const found = await prisma.material.findUnique({
+      where: { id: sessionMaterialId },
+      select: { id: true, name: true, type: true, url: true },
+    });
+    if (found?.url) {
+      const downloadUrl = await getPresignedUrl(found.url);
+      material = {
+        id: found.id,
+        name: found.name,
+        type: found.type,
+        downloadUrl,
+      };
+    }
+  }
+
+  // 7. 입장 허가 응답
   res.json({
     sessionId,
     title: session.title,
     classId: session.classId,
-    materialId: session.materialId ?? null,
+    materialId: sessionMaterialId,
+    material,
   });
 });
 


### PR DESCRIPTION
## 🛠 Issue

학생이 QR 링크를 통해 세션에 입장할 때,
HTTP `POST /sessions/:sessionId/join` 응답에는 `materialId`만 포함되고
실제 자료 정보인 `material` 객체는 포함되지 않는 문제가 있었습니다.

이로 인해 학생 클라이언트는 입장 직후 현재 수업 자료를 즉시 표시할 수 없었으며,
학생 토큰으로 `GET /materials/:materialId/download-url` 호출 시
`403 NOT_CLASS_MEMBER`가 발생하여 PDF URL을 직접 조회할 수도 없었습니다.

이번 작업에서는 HTTP join 응답에 현재 세션의 material 정보와
presigned download URL을 함께 포함하도록 수정했습니다.

---

## ✨ Changes

* `POST /sessions/:sessionId/join` 응답에 `material` 객체 추가
* material 존재 시 presigned download URL 생성 후 함께 반환
* 응답 구조에 다음 정보 포함

  * `id`
  * `name`
  * `type`
  * `downloadUrl`
* material이 없는 경우 `material: null` 유지
* 기존 `materialId` 응답 구조 유지
* 소켓 `JOIN_SUCCESS` 응답 구조와 HTTP join 응답 구조 일관성 개선

---

## 📌 Notes

* 프론트는 `materialId`만으로 PDF URL을 복원할 수 없습니다.
* 학생 권한으로 material download API 접근 시 `403 NOT_CLASS_MEMBER`가 발생하는 구조를 우회하기 위해 join 응답에 presigned URL을 직접 포함했습니다.
* `found?.url` 방어 로직을 추가하여 material 데이터 이상 상황에서도 안전하게 처리되도록 했습니다.
