### PR TITLE
[Fix]: #155-세션 생성 시 DB Session 레코드 저장 추가

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1771,6 +1771,18 @@ if (
     createdAt: Date.now(),
   };
 
+  await prisma.session.create({
+    data: {
+      id: sessionId,
+      classId: classId.trim(),
+      materialId: normalizedMaterialId,
+      title: title.trim(),
+      capacity: parsedCapacity,
+      passwordHash,
+      status: 'ACTIVE',
+    },
+  });
+
   await sessionStore.create(sessionId, sessionData);
 
 logger.info("session created", { sessionId, classId: sessionData.classId });


### PR DESCRIPTION
## 🛠 Issue

현재 수업 세션 생성 시 세션 정보가 Redis에만 저장되고 DB의 Session 테이블에는 저장되지 않고 있었습니다.

이로 인해 퀴즈 문항 생성 시 QuizQuestion이 Session을 외래키로 참조하는 과정에서,
해당 sessionId가 DB에 존재하지 않아 `QuizQuestion_sessionId_fkey` Foreign Key Constraint 오류가 발생했습니다.

이번 작업에서는 세션 생성 시 Redis와 함께 DB Session 레코드도 생성하도록 수정했습니다.

---

## ✨ Changes

- 세션 생성 시 DB Session 레코드 생성 로직 추가
- QuizQuestion 생성 시 참조 가능한 sessionId 보장
- Redis 세션과 DB Session 간 기본 동기화 구조 보완
- 퀴즈 생성 시 Foreign Key Constraint 오류 해결

---

## 📌 Notes

- Session 모델의 title, capacity, passwordHash, materialId 필드는 nullable 구조를 그대로 사용합니다.
- DB Session 생성 이후 Redis 세션을 생성하도록 순서를 조정하여 데이터 불일치 가능성을 줄였습니다.
- 현재 status는 ACTIVE로 저장되며, 이후 세션 종료 상태 동기화는 추가 이슈에서 확장 가능합니다.