### PR TITLE
[Feat]: #159-퀴즈 점수 기반 PDF export 제한 비활성화

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -513,18 +513,21 @@ app.post('/export/pdf', express.json({ limit: '5mb' }), requireAuth, async (req,
     }
 
     // ── 3-1. 퀴즈 통과 검증 (학생만) ─────────────────────────────
-    if (req.role === 'student') {
-      const correctCount = await prisma.quizAnswer.count({
-        where: {
-          sessionId,
-          userId: req.userId,
-          isCorrect: true,
-        },
-      });
-      if (correctCount < 2) {
-        return sendHttpError(res, 403, ERRORS.QUIZ_NOT_PASSED, 'QUIZ_NOT_PASSED');
-      }
-    }
+    // TODO(#159): 발표 범위에서 퀴즈 기능 제외 → 퀴즈 점수 기반 PDF export 제한 임시 비활성화
+    // 추후 퀴즈 기능 재도입 시 아래 로직 주석 해제
+    // if (req.role === 'student') {
+    //   const correctCount = await prisma.quizAnswer.count({
+    //     where: {
+    //       sessionId,
+    //       userId: req.userId,
+    //       isCorrect: true,
+    //     },
+    //   });
+    //
+    //   if (correctCount < 2) {
+    //     return sendHttpError(res, 403, ERRORS.QUIZ_NOT_PASSED, 'QUIZ_NOT_PASSED');
+    //   }
+    // }
 
     // ── 4. 교사 판서 읽기 ─────────────────────────────────────────
     let teacherStrokes = [];


### PR DESCRIPTION
🛠 Issue

현재 PDF export 기능은 학생이 복습 퀴즈에서 2문제 이상 정답을 맞힌 경우에만 사용할 수 있도록 제한되어 있습니다.

이번 발표 범위에서는 이해도 체크 / 질문 / 퀴즈 기능을 제외하고, 수업 종료 후 PDF export 기능까지만 시연하기로 결정되었습니다.

이에 따라 발표 범위에서는 퀴즈 점수와 관계없이 모든 학생이 자신의 자료를 PDF로 추출할 수 있도록 기존 퀴즈 통과 검증을 임시 비활성화합니다.

✨ Changes
POST /export/pdf 내부 퀴즈 통과 검증 로직 주석 처리
기존 classMember 기반 접근 검증 유지
퀴즈 미통과(QUIZ_NOT_PASSED) 차단 로직 비활성화
추후 재활성화를 고려하여 기존 코드 구조 유지 및 TODO 주석 추가
📌 Notes
이번 변경은 발표 범위 대응을 위한 임시 비활성화입니다.
퀴즈 기능 재도입 시 기존 검증 로직을 그대로 복구할 수 있도록 구조를 유지했습니다.
교사/학생 모두 기존 classMember 기반 접근 제어는 그대로 유지됩니다.