### PR TITLE
[Fix]: #164-Session materialId DB 동기화 누락 수정

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1111,13 +1111,21 @@ app.post(
       logger.info('material uploaded', { materialId: material.id, classId });
 
       if (sessionId) {
-        const updatedSession = await sessionStore.update(sessionId, { materialId: material.id });
+        const [updatedSession] = await Promise.all([
+          sessionStore.update(sessionId, { materialId: material.id }),
+          prisma.session.update({
+            where: { id: sessionId },
+            data: { materialId: material.id },
+          }),
+        ]);
 
         if (updatedSession) {
           logger.info('redis session materialId synced', { sessionId, materialId: material.id });
         } else {
           logger.warn('redis session not found while syncing materialId', { sessionId, materialId: material.id });
         }
+
+        logger.info('db session materialId synced', { sessionId, materialId: material.id });
       }
 
       return res.status(201).json(material);


### PR DESCRIPTION
## 🛠️ Summary

/materials/pdf에서 자료 업로드 시 Redis sessionStore만 materialId를 갱신하고,
DB Session 테이블은 업데이트하지 않던 문제를 수정했습니다.

이제 material upload 시 Redis와 DB Session.materialId를 함께 동기화하여,
/export/pdf에서 정상적으로 material 조회가 가능하도록 개선했습니다.

---

## ✨ Changes

- material upload 시 prisma.session.update 추가
- Redis sessionStore와 DB Session 상태 동기화
- Redis + DB 업데이트를 Promise.all로 병렬 처리
- DB 업데이트 성공 log 추가
- 기존 Redis warn log 유지

---

## 📌 Result

- /export/pdf에서 MATERIAL_NOT_FOUND 오류 해결
- Redis와 DB 간 Session 상태 불일치 문제 해결