### PR TITLE
[Fix]: #166-세션 참여자 기반 PDF export 권한 검증 적용

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -503,12 +503,9 @@ app.post('/export/pdf', express.json({ limit: '5mb' }), requireAuth, async (req,
       return sendHttpError(res, 400, ERRORS.MATERIAL_NOT_FOUND, 'MATERIAL_NOT_FOUND');
     }
 
-    // ── 3. 권한 검증: 세션 소속 클래스 멤버인지 확인 ──────────────
-    const membership = await prisma.classMember.findFirst({
-      where: { classId: session.classId, userId: req.userId },
-      select: { id: true },
-    });
-    if (!membership) {
+    // ── 3. 권한 검증: 소켓으로 세션에 입장한 적 있는지 확인 ──────────
+    const isMember = await redis.sismember(`session:${sessionId}:participants`, req.userId);
+    if (!isMember) {
       return sendHttpError(res, 403, ERRORS.FORBIDDEN, 'NOT_SESSION_MEMBER');
     }
 
@@ -2476,6 +2473,9 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
     socket.data.studentsRoom = studentsRoom;
     socket.data.teachersRoom = teachersRoom;
     socket.data.roleRoom = roleRoom;
+
+    await redis.sadd(`session:${roomId}:participants`, socket.data.userId);
+    await redis.expire(`session:${roomId}:participants`, APP_CONFIG.USER_SESSION_CACHE_TTL);
 
     logger.info("✅join room success", {
       socketId: socket.id,


### PR DESCRIPTION
## 🛠 Issue

현재 `POST /export/pdf`는 `ClassMember` 기반으로 권한을 검증하고 있어,  
QR 링크를 통해 세션에 정상 입장한 학생도 클래스 멤버가 아니라면 `NOT_SESSION_MEMBER (403)`가 발생하는 문제가 있습니다.

`POST /sessions/:sessionId/join`은 세션 입장만 처리하며 DB에 `ClassMember`를 생성하지 않기 때문에,  
실제 수업에 참여 중인 학생과 export 권한 검증 기준이 일치하지 않는 상태였습니다.

이번 작업에서는 `ClassMember` 기반 검증 대신,  
실제로 소켓을 통해 세션에 입장한 사용자(Session Participant) 기준으로 export 권한을 검증하도록 수정했습니다.

---

## ✨ Changes

- `join_room` 성공 시 Redis `session:{sessionId}:participants` Set에 `userId` 저장
- participant Set TTL 적용 (`APP_CONFIG.USER_SESSION_CACHE_TTL`)
- `POST /export/pdf` 권한 검증을 `ClassMember` 조회 → Redis `sismember` 체크로 변경
- 세션 종료 이후에도 일정 시간 동안 export 가능하도록 participant 정보 유지

---

## 📌 Notes

- 기존 `session:{sessionId}:users` Set은 세션 관리 용도로 유지
- export 권한 검증 전용 participant Set을 별도로 추가
- QR 입장 학생도 실제 세션 참여 이력이 있으면 PDF export 가능