### PR TITLE
[Fix]: #168- PDF export teacher stroke validation 추가

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -568,7 +568,9 @@ app.post('/export/pdf', express.json({ limit: '5mb' }), requireAuth, async (req,
     }
 
     // 기존 normalizeStroke 규칙 적용 (c/w/page 누락된 legacy 데이터 보정)
-    teacherStrokes = teacherStrokes.map(normalizeStroke);
+    teacherStrokes = teacherStrokes
+      .map(normalizeStroke)
+      .filter(s => s && Array.isArray(s.points) && s.points.length > 1);
 
     // tick 오름차순 정렬 (t 없는 legacy stroke는 0 취급 → 앞쪽 배치)
     // t가 없는 데이터는 정확한 순서를 알 수 없으므로 유효 tick stroke 앞에 배치


### PR DESCRIPTION
## 🛠 Issue

POST /export/pdf 호출 시 세션/멤버 검증은 통과하지만,
PDF 생성 단계에서 `PDF_EXPORT_FAILED` 500 에러가 발생했습니다.

서버 로그 확인 결과, `teacherStrokes` 중 `points` 값이 없는 stroke가 포함되어
PDF 렌더링 과정에서 `stroke.points.slice(...)` 호출 시 예외가 발생했습니다.

이번 작업에서는 PDF export 전 teacher stroke 유효성 검증을 추가하여
비정상 stroke 데이터로 인해 PDF 생성이 실패하지 않도록 수정합니다.

---

## ✨ Changes

* PDF export 전 `teacherStrokes` 유효성 검증 추가
* `points`가 배열이 아니거나 길이가 부족한 stroke 필터링
* studentStrokes와 동일한 기준으로 teacher stroke 정규화 적용
* 비정상 legacy stroke 데이터로 인한 PDF_EXPORT_FAILED 방지

---

## 📌 Notes

* 기존에는 studentStrokes만 유효성 검증을 수행하고 있었음
* teacherStrokes는 normalize 이후 그대로 사용되고 있었음
* legacy 또는 비정상 stroke 데이터가 포함될 경우 PDF export가 실패할 수 있었음
* PDF export 안정성 및 예외 처리 보완 목적