### PR TITLE
[Fix]: #170- PDF export 교사 판서 누락 수정

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -568,8 +568,10 @@ app.post('/export/pdf', express.json({ limit: '5mb' }), requireAuth, async (req,
     }
 
     // 기존 normalizeStroke 규칙 적용 (c/w/page 누락된 legacy 데이터 보정)
+    // pts → points 변환: Redis 저장 형식(pts)과 렌더링 필드(points) 통일
     teacherStrokes = teacherStrokes
       .map(normalizeStroke)
+      .map(s => s && !s.points && Array.isArray(s.pts) ? { ...s, points: s.pts } : s)
       .filter(s => s && Array.isArray(s.points) && s.points.length > 1);
 
     // tick 오름차순 정렬 (t 없는 legacy stroke는 0 취급 → 앞쪽 배치)


### PR DESCRIPTION
## 🛠 Issue

현재 PDF export 과정에서 교사 판서 데이터가 정상적으로 렌더링되지 않는 문제가 있습니다.

원인을 확인한 결과, Redis에 저장되는 teacher stroke는 `pts` 필드를 사용하고 있지만,
PDF export 렌더링 로직은 `points` 필드를 기준으로 동작하고 있었습니다.

이로 인해 export 과정에서 모든 교사 stroke가 필터링되어,
최종 PDF에 교사 판서가 포함되지 않는 현상이 발생했습니다.

이번 작업에서는 export 로딩 단계에서 `pts → points` 정규화를 추가하여
Redis 저장 형식과 렌더링 필드 구조를 통일합니다.

---

## ✨ Changes

* PDF export 로딩 단계에서 `pts → points` 필드 정규화 추가
* Redis teacher stroke 형식과 export 렌더링 구조 통일
* teacher stroke filter 조건 정상 동작하도록 수정
* PDF export 시 교사 판서가 정상 렌더링되도록 개선

---

## 📌 Notes

* Redis 저장 teacher stroke 구조는 `pts` 필드 기반
* export 렌더링 로직은 `points` 필드를 기준으로 동작 중이었음
* 기존에는 `s.points === undefined` 상태로 모든 stroke가 filter에서 제거되었음
* legacy stroke normalize 흐름과 동일한 단계에서 정규화 적용