### PR TITLE
[Fix]: #174- poll:start 이벤트 교사 룸 누락 수정

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -2804,8 +2804,8 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
         : null,
     });
 
-    const { studentsRoom } = getRoleRooms(sessionId);
-    io.to(studentsRoom).emit(SOCKET_EVENTS.POLL_START, {
+    const { studentsRoom, teachersRoom } = getRoleRooms(sessionId);
+    io.to(studentsRoom).to(teachersRoom).emit(SOCKET_EVENTS.POLL_START, {
       pollId,
       question: normalizedQuestion,
       options,


### PR DESCRIPTION
  poll:start 이벤트가 학생 룸에만 전송되고 있어 교사 화면에서 투표 진행 중 상태가
  표시되지 않는 버그 수정

  - io.to(studentsRoom).emit → io.to(studentsRoom).to(teachersRoom).emit으로 변경
  - poll:end, poll:result는 정상 동작 확인