### PR TITLE
[Feat] #176 퀴즈 통과 조건 PDF export 제한 기능 복구

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -510,21 +510,19 @@ app.post('/export/pdf', express.json({ limit: '5mb' }), requireAuth, async (req,
     }
 
     // ── 3-1. 퀴즈 통과 검증 (학생만) ─────────────────────────────
-    // TODO(#159): 발표 범위에서 퀴즈 기능 제외 → 퀴즈 점수 기반 PDF export 제한 임시 비활성화
-    // 추후 퀴즈 기능 재도입 시 아래 로직 주석 해제
-    // if (req.role === 'student') {
-    //   const correctCount = await prisma.quizAnswer.count({
-    //     where: {
-    //       sessionId,
-    //       userId: req.userId,
-    //       isCorrect: true,
-    //     },
-    //   });
-    //
-    //   if (correctCount < 2) {
-    //     return sendHttpError(res, 403, ERRORS.QUIZ_NOT_PASSED, 'QUIZ_NOT_PASSED');
-    //   }
-    // }
+    if (req.role === 'student') {
+      const correctCount = await prisma.quizAnswer.count({
+        where: {
+          sessionId,
+          userId: req.userId,
+          isCorrect: true,
+        },
+      });
+
+      if (correctCount < 2) {
+        return sendHttpError(res, 403, ERRORS.QUIZ_NOT_PASSED, 'QUIZ_NOT_PASSED');
+      }
+    }
 
     // ── 4. 교사 판서 읽기 ─────────────────────────────────────────
     let teacherStrokes = [];


### PR DESCRIPTION
## 📌 Summary

* PDF export 시 퀴즈 통과 검증 로직을 재활성화
* 학생은 퀴즈 정답 2개 이상 획득 시에만 PDF export 가능
* 미통과 시 403(`QUIZ_NOT_PASSED`) 응답 반환

## 🔧 Changes

* `POST /export/pdf` 내부 퀴즈 통과 검증 로직 주석 해제
* 학생의 정답 개수(`correctCount`) 확인 로직 복구
* 퀴즈 미통과 시 PDF export 차단 기능 복구

## ✅ Test

* [ ] 정답 0개 → PDF export 실패
* [ ] 정답 1개 → PDF export 실패
* [ ] 정답 2개 → PDF export 성공
* [ ] 정답 3개 → PDF export 성공
