### PR TITLE
[Fix] 복습 퀴즈 권한 확인 방식 수정

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -556,8 +556,8 @@ app.post('/export/pdf', express.json({ limit: '5mb' }), requireAuth, async (req,
     }
 
     // ── 3. 권한 검증: 소켓으로 세션에 입장한 적 있는지 확인 ──────────
-    const isMember = await redis.sismember(`session:${sessionId}:participants`, req.userId);
-    if (!isMember) {
+    const isParticipant = await redis.sismember(`session:${sessionId}:participants`, String(req.userId));
+    if (!isParticipant) {
       return sendHttpError(res, 403, ERRORS.FORBIDDEN, 'NOT_SESSION_MEMBER');
     }
 
@@ -2083,17 +2083,8 @@ app.get(ROUTES.QUIZ_BASE, requireAuth, async (req, res) => {
     });
     if (!session) return sendHttpError(res, 404, ERRORS.SESSION_NOT_FOUND, 'SESSION_NOT_FOUND');
 
-    const skipMemberCheck =
-      process.env.NODE_ENV !== 'production' &&
-      process.env.DEV_SKIP_CLASS_MEMBER_CHECK === 'true';
-
-    if (!skipMemberCheck) {
-      const membership = await prisma.classMember.findFirst({
-        where: { classId: session.classId, userId: req.userId },
-        select: { id: true },
-      });
-      if (!membership) return sendHttpError(res, 403, ERRORS.FORBIDDEN, 'NOT_CLASS_MEMBER');
-    }
+    const isParticipant = await redis.sismember(`session:${sessionId}:participants`, String(req.userId));
+    if (!isParticipant) return sendHttpError(res, 403, ERRORS.FORBIDDEN, 'NOT_SESSION_MEMBER');
 
     if (!['teacher', 'student'].includes(req.role))
       return sendHttpError(res, 403, ERRORS.FORBIDDEN, 'INVALID_ROLE');
@@ -2665,7 +2656,7 @@ socket.on(SOCKET_EVENTS.JOIN_ROOM, async ({ roomId, classId, materialId }) => {
     socket.data.teachersRoom = teachersRoom;
     socket.data.roleRoom = roleRoom;
 
-    await redis.sadd(`session:${roomId}:participants`, socket.data.userId);
+    await redis.sadd(`session:${roomId}:participants`, String(socket.data.userId));
     await redis.expire(`session:${roomId}:participants`, APP_CONFIG.USER_SESSION_CACHE_TTL);
 
     logger.info("✅join room success", {


### PR DESCRIPTION
## 📌 Summary

* GET /sessions/:sessionId/quiz의 권한 확인 방식을 수정했습니다.
* 기존 ClassMember 기반 권한 확인을 제거하고, Redis의 `session:{sessionId}:participants`를 이용한 세션 참여 여부 확인으로 변경했습니다.
* POST /export/pdf와 동일한 권한 정책을 적용하여 API 간 권한 확인 방식을 일관되게 맞췄습니다.
* Redis에 사용자 정보를 저장하고 조회할 때 모두 문자열(String)로 처리하도록 수정하여 타입 불일치 가능성을 제거했습니다.

## 🔧 변경 사항

* GET /sessions/:sessionId/quiz의 ClassMember 조회 로직 제거
* Redis `session:{sessionId}:participants`를 이용한 세션 참여 여부 확인 로직 적용
* `isMember` → `isParticipant` 변수명 변경
* Redis `SADD` 시 `String(socket.data.userId)` 적용
* Redis `SISMEMBER` 조회 시 `String(req.userId)` 적용

## ✅ 테스트

* 세션에 참여한 학생이 복습 퀴즈를 정상적으로 조회하는지 확인
* 세션에 참여하지 않은 사용자가 403 Forbidden을 반환하는지 확인
* PDF Export와 동일한 권한 정책이 적용되는지 확인
* Redis 저장/조회 시 타입 불일치 없이 정상적으로 권한이 확인되는지 확인
