### PR TITLE
[Fix]: #185- 퀴즈 재응시 횟수 카운트 기준 수정

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -2284,9 +2284,12 @@ app.delete(ROUTES.QUIZ_ITEM, requireAuth, requireTeacherRole, async (req, res) =
 });
 
 // ✅ #132: 복습 퀴즈 HTTP 제출 (학생 전용, ARCHIVED 세션)
+// ✅ #185: isRetryStart — 프론트가 "다시 응시하기"로 3문제 세트를 새로 시작할 때만 true로 보내는 플래그.
+//   첫 응시(당일 최초 응시)의 문항 제출에는 포함하지 않으며, 재응시 세트의 "첫 번째" 문항 제출에만 true.
+//   같은 세트 내 두 번째/세 번째 문항 제출에는 보내지 않음(또는 false) — 서버는 이 시점에만 일일 재응시 횟수를 증가시킴.
 app.post(ROUTES.QUIZ_SUBMIT, requireAuth, async (req, res) => {
   const { sessionId } = req.params;
-  const { questionId, answer } = req.body;
+  const { questionId, answer, isRetryStart } = req.body;
   const userId = req.userId;
 
   // 1. 학생 전용
@@ -2301,6 +2304,8 @@ app.post(ROUTES.QUIZ_SUBMIT, requireAuth, async (req, res) => {
     return sendHttpError(res, 400, ERRORS.PAYLOAD_INVALID, 'answer 누락');
   if (trimmedAnswer.length > MAX_QUIZ_ANSWER_LENGTH)
     return sendHttpError(res, 400, ERRORS.PAYLOAD_INVALID, `최대 ${MAX_QUIZ_ANSWER_LENGTH}자`);
+  if (isRetryStart !== undefined && typeof isRetryStart !== 'boolean')
+    return sendHttpError(res, 400, ERRORS.PAYLOAD_INVALID, 'isRetryStart 형식 오류');
 
   const trimmedQId = questionId.trim();
 
@@ -2321,18 +2326,8 @@ app.post(ROUTES.QUIZ_SUBMIT, requireAuth, async (req, res) => {
     });
     if (!membership) return sendHttpError(res, 403, ERRORS.FORBIDDEN, 'NOT_CLASS_MEMBER');
 
-    // 5. 일일 응시 횟수 검증 — INCR 선행으로 경쟁 조건 방지 (소켓과 동일 정책)
-    const dailyKey = `quiz:count:${userId}:${getKSTDateString()}`;
-    try {
-      const count = await redis.incr(dailyKey);
-      if (count === 1) await redis.expire(dailyKey, getSecondsUntilMidnightKST());
-      if (count > MAX_QUIZ_DAILY_ATTEMPTS)
-        return sendHttpError(res, 429, ERRORS.QUIZ_DAILY_LIMIT_EXCEEDED, `하루 최대 ${MAX_QUIZ_DAILY_ATTEMPTS}회까지 응시할 수 있습니다`);
-    } catch (e) {
-      logger.warn('quiz daily count check failed, allowing submission', { userId, err: e?.message });
-    }
-
-    // 6. 문항 조회 + 채점
+    // 5. 문항 조회 + 채점 — 재응시 횟수 검증보다 먼저 수행해서, 잘못된 questionId로는
+    //    재응시 횟수가 소모되지 않도록 함
     let correctAnswer;
     try {
       const q = await prisma.quizQuestion.findFirst({
@@ -2348,6 +2343,19 @@ app.post(ROUTES.QUIZ_SUBMIT, requireAuth, async (req, res) => {
 
     const normalizedCorrectAnswer = String(correctAnswer).trim();
     const isCorrect = trimmedAnswer === normalizedCorrectAnswer;
+
+    // 6. 재응시 세트 시작 시점에만 일일 재응시 횟수 검증 — 첫 응시는 카운트하지 않음
+    if (isRetryStart === true) {
+      const dailyKey = `quiz:count:${userId}:${getKSTDateString()}`;
+      try {
+        const count = await redis.incr(dailyKey);
+        if (count === 1) await redis.expire(dailyKey, getSecondsUntilMidnightKST());
+        if (count > MAX_QUIZ_DAILY_ATTEMPTS)
+          return sendHttpError(res, 429, ERRORS.QUIZ_DAILY_LIMIT_EXCEEDED, `하루 최대 ${MAX_QUIZ_DAILY_ATTEMPTS}회까지 재응시할 수 있습니다`);
+      } catch (e) {
+        logger.warn('quiz daily count check failed, allowing submission', { userId, err: e?.message });
+      }
+    }
 
     // 7. DB 저장 — 재응시 시 최신 답안으로 재채점되도록 upsert 사용
     try {

--- a/tests/185-quiz-retry-limit.test.js
+++ b/tests/185-quiz-retry-limit.test.js
@@ -1,0 +1,181 @@
+/**
+ * #185 일일 재응시 횟수 제한 회귀 테스트
+ *
+ * 실행: npx jest tests/185-quiz-retry-limit.test.js --runInBand --forceExit
+ *
+ * 전제: Redis 실행 중
+ * Prisma: jest.mock 처리
+ *
+ * 검증 대상: POST /sessions/:sessionId/quiz/submit 의 isRetryStart 플래그 기반
+ * 일일 재응시 횟수 제한. 첫 응시(당일 최초 3문항)는 카운트되지 않고, isRetryStart:true로
+ * 시작한 재응시 세트만 하루 최대 2회로 제한됨을 확인한다.
+ */
+require('dotenv').config();
+
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const redis = require('../src/lib/redis');
+
+const PORT = 3103;
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-change-me';
+const SESSION_ID = `test-session-185-${Date.now()}`;
+const CLASS_ID = 'test-class-185';
+const VALID_QUESTION_IDS = ['q1', 'q2', 'q3'];
+const INVALID_QUESTION_ID = 'bad-question-id';
+
+const mockSessionFindUnique = jest.fn();
+const mockClassMemberFindFirst = jest.fn();
+const mockQuizQuestionFindFirst = jest.fn();
+const mockQuizAnswerUpsert = jest.fn();
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn().mockImplementation(() => ({
+    session: { findUnique: mockSessionFindUnique },
+    classMember: { findFirst: mockClassMemberFindFirst },
+    quizQuestion: { findFirst: mockQuizQuestionFindFirst },
+    quizAnswer: { upsert: mockQuizAnswerUpsert },
+  })),
+}));
+
+let serverInstance;
+let ioInstance;
+
+function post(urlPath, body, token) {
+  return new Promise((resolve, reject) => {
+    const bodyStr = JSON.stringify(body);
+    const req = http.request(
+      {
+        hostname: 'localhost',
+        port: PORT,
+        path: urlPath,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(bodyStr),
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+      },
+      (res) => {
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => {
+          const buf = Buffer.concat(chunks);
+          let json = null;
+          try { json = JSON.parse(buf.toString()); } catch (_) {}
+          resolve({ status: res.statusCode, json });
+        });
+      },
+    );
+    req.on('error', reject);
+    req.write(bodyStr);
+    req.end();
+  });
+}
+
+function makeToken(userId) {
+  return jwt.sign({ userId, role: 'student' }, JWT_SECRET, { expiresIn: '1h' });
+}
+
+function getKSTDateString() {
+  return new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10).replace(/-/g, '');
+}
+
+function dailyKeyFor(userId) {
+  return `quiz:count:${userId}:${getKSTDateString()}`;
+}
+
+beforeAll(async () => {
+  const { server, io } = require('../src/server');
+  serverInstance = server;
+  ioInstance = io;
+  await new Promise((resolve) => server.listen(PORT, resolve));
+});
+
+afterAll(async () => {
+  ioInstance.close();
+  await new Promise((resolve) => serverInstance.close(resolve));
+}, 20000);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  mockSessionFindUnique.mockResolvedValue({ classId: CLASS_ID, status: 'ARCHIVED' });
+  mockClassMemberFindFirst.mockResolvedValue({ id: 'membership-1' });
+  mockQuizQuestionFindFirst.mockImplementation(({ where }) =>
+    VALID_QUESTION_IDS.includes(where.id) ? Promise.resolve({ answer: 'O' }) : Promise.resolve(null),
+  );
+  mockQuizAnswerUpsert.mockResolvedValue({});
+});
+
+test('1. isRetryStart 없이 첫 응시 3문항을 제출해도 daily count가 증가하지 않는다', async () => {
+  const userId = `student-185-1-${Date.now()}`;
+  const token = makeToken(userId);
+
+  for (const questionId of VALID_QUESTION_IDS) {
+    const res = await post(`/sessions/${SESSION_ID}/quiz/submit`, { questionId, answer: 'O' }, token);
+    expect(res.status).toBe(200);
+  }
+
+  const count = await redis.get(dailyKeyFor(userId));
+  expect(count).toBeNull();
+
+  await redis.del(dailyKeyFor(userId));
+});
+
+test('2~3. 재응시 시작 1회, 2회는 통과하고 3번째 재응시 시작은 429를 반환한다', async () => {
+  const userId = `student-185-2-${Date.now()}`;
+  const token = makeToken(userId);
+
+  // 1차 재응시 세트 (첫 문항만 isRetryStart:true)
+  const retry1 = await post(`/sessions/${SESSION_ID}/quiz/submit`, { questionId: 'q1', answer: 'O', isRetryStart: true }, token);
+  expect(retry1.status).toBe(200);
+  const retry1Rest = await post(`/sessions/${SESSION_ID}/quiz/submit`, { questionId: 'q2', answer: 'O' }, token);
+  expect(retry1Rest.status).toBe(200);
+
+  // 2차 재응시 세트
+  const retry2 = await post(`/sessions/${SESSION_ID}/quiz/submit`, { questionId: 'q1', answer: 'X', isRetryStart: true }, token);
+  expect(retry2.status).toBe(200);
+
+  // 3차 재응시 세트 — 한도 초과
+  const retry3 = await post(`/sessions/${SESSION_ID}/quiz/submit`, { questionId: 'q1', answer: 'O', isRetryStart: true }, token);
+  expect(retry3.status).toBe(429);
+  expect(retry3.json.code).toBe('QUIZ_DAILY_LIMIT_EXCEEDED');
+
+  await redis.del(dailyKeyFor(userId));
+});
+
+test('4. isRetryStart가 boolean이 아니면 400을 반환한다', async () => {
+  const userId = `student-185-4-${Date.now()}`;
+  const token = makeToken(userId);
+
+  const res = await post(`/sessions/${SESSION_ID}/quiz/submit`, { questionId: 'q1', answer: 'O', isRetryStart: 'true' }, token);
+  expect(res.status).toBe(400);
+
+  await redis.del(dailyKeyFor(userId));
+});
+
+test('5. 잘못된 questionId로 재응시를 시작하면 404를 반환하고 daily count는 소모되지 않는다', async () => {
+  const userId = `student-185-5-${Date.now()}`;
+  const token = makeToken(userId);
+
+  const badRes = await post(
+    `/sessions/${SESSION_ID}/quiz/submit`,
+    { questionId: INVALID_QUESTION_ID, answer: 'O', isRetryStart: true },
+    token,
+  );
+  expect(badRes.status).toBe(404);
+
+  const count = await redis.get(dailyKeyFor(userId));
+  expect(count).toBeNull();
+
+  // 정상 questionId로 재응시를 시작하면 여전히 1회차로 처리되어야 함
+  const goodRes = await post(
+    `/sessions/${SESSION_ID}/quiz/submit`,
+    { questionId: 'q1', answer: 'O', isRetryStart: true },
+    token,
+  );
+  expect(goodRes.status).toBe(200);
+  expect(await redis.get(dailyKeyFor(userId))).toBe('1');
+
+  await redis.del(dailyKeyFor(userId));
+});


### PR DESCRIPTION
## 📌 Summary

* 퀴즈 재응시 횟수 카운트 기준을 문항 제출 단위에서 재응시 시작 단위로 변경했습니다.
* `isRetryStart` 필드를 추가하여 재응시 시작 시점에만 일일 재응시 횟수를 증가시키도록 수정했습니다.
* 문항 유효성 검증을 재응시 횟수 검증보다 먼저 수행하도록 변경하여, 잘못된 `questionId`로 인해 재응시 횟수가 차감되지 않도록 수정했습니다.
* 재응시 횟수 검증 관련 테스트를 추가했습니다.

## 🔧 변경 사항

* `POST /sessions/:sessionId/quiz/submit` 요청에 `isRetryStart` 필드 추가
* `isRetryStart` 타입 검증 추가
* 문항 조회를 재응시 횟수 검증보다 먼저 수행하도록 로직 순서 변경
* `isRetryStart === true`일 때만 일일 재응시 횟수 증가 및 제한 검증 수행
* 재응시 카운트 관련 회귀 테스트(`tests/185-quiz-retry-limit.test.js`) 추가

## ✅ 테스트

* 기존 퀴즈 제출 관련 테스트 통과
* 첫 응시 시 재응시 카운트가 증가하지 않는지 확인
* 재응시 1·2회 시작은 정상 처리되는지 확인
* 3번째 재응시 시작 시 `QUIZ_DAILY_LIMIT_EXCEEDED(429)` 반환 확인
* `isRetryStart` 타입 검증(400) 확인
* 잘못된 `questionId` 요청 시 재응시 횟수가 차감되지 않는지 확인
