### PR TITLE
[Fix]: #187- QR 학생 퀴즈 권한 체크 방식 수정

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -2313,18 +2313,15 @@ app.post(ROUTES.QUIZ_SUBMIT, requireAuth, async (req, res) => {
     // 3. 세션 확인 — ARCHIVED만 허용
     const dbSession = await prisma.session.findUnique({
       where: { id: sessionId },
-      select: { classId: true, status: true },
+      select: { status: true },
     });
     if (!dbSession) return sendHttpError(res, 404, ERRORS.SESSION_NOT_FOUND, 'SESSION_NOT_FOUND');
     if (dbSession.status !== 'ARCHIVED')
       return sendHttpError(res, 400, ERRORS.PAYLOAD_INVALID, 'SESSION_NOT_ENDED');
 
-    // 4. classMember 검증
-    const membership = await prisma.classMember.findFirst({
-      where: { classId: dbSession.classId, userId },
-      select: { id: true },
-    });
-    if (!membership) return sendHttpError(res, 403, ERRORS.FORBIDDEN, 'NOT_CLASS_MEMBER');
+    // 4. 세션 참여 여부 검증 (QR 입장 학생은 ClassMember가 아니므로 participants Set 기준으로 확인)
+    const isParticipant = await redis.sismember(`session:${sessionId}:participants`, String(userId));
+    if (!isParticipant) return sendHttpError(res, 403, ERRORS.FORBIDDEN, 'NOT_SESSION_MEMBER');
 
     // 5. 문항 조회 + 채점 — 재응시 횟수 검증보다 먼저 수행해서, 잘못된 questionId로는
     //    재응시 횟수가 소모되지 않도록 함
@@ -2393,16 +2390,13 @@ app.get(ROUTES.QUIZ_RESULT, requireAuth, async (req, res) => {
     // 1. 세션 확인 (DB 기준)
     const session = await prisma.session.findUnique({
       where: { id: sessionId },
-      select: { classId: true, status: true },
+      select: { status: true },
     });
     if (!session) return sendHttpError(res, 404, ERRORS.SESSION_NOT_FOUND, 'SESSION_NOT_FOUND');
 
-    // 2. classMember 검증
-    const membership = await prisma.classMember.findFirst({
-      where: { classId: session.classId, userId },
-      select: { id: true },
-    });
-    if (!membership) return sendHttpError(res, 403, ERRORS.FORBIDDEN, 'NOT_CLASS_MEMBER');
+    // 2. 세션 참여 여부 검증 (participants Set 기준)
+    const isParticipant = await redis.sismember(`session:${sessionId}:participants`, String(userId));
+    if (!isParticipant) return sendHttpError(res, 403, ERRORS.FORBIDDEN, 'NOT_SESSION_MEMBER');
 
     // 3. role 검증
     if (!['teacher', 'student'].includes(req.role))

--- a/tests/183-quiz-submit-retake.test.js
+++ b/tests/183-quiz-submit-retake.test.js
@@ -19,20 +19,17 @@ const redis = require('../src/lib/redis');
 const PORT = 3102;
 const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-change-me';
 const SESSION_ID = `test-session-quiz-${Date.now()}`;
-const CLASS_ID = 'test-class-quiz';
 const QUESTION_ID = 'test-question-quiz-1';
 const USER_ID = `test-student-quiz-1-${Date.now()}`;
 const USER_ID_2 = `test-student-quiz-2-${Date.now()}`;
 
 const mockSessionFindUnique = jest.fn();
-const mockClassMemberFindFirst = jest.fn();
 const mockQuizQuestionFindFirst = jest.fn();
 const mockQuizAnswerUpsert = jest.fn();
 
 jest.mock('@prisma/client', () => ({
   PrismaClient: jest.fn().mockImplementation(() => ({
     session: { findUnique: mockSessionFindUnique },
-    classMember: { findFirst: mockClassMemberFindFirst },
     quizQuestion: { findFirst: mockQuizQuestionFindFirst },
     quizAnswer: { upsert: mockQuizAnswerUpsert },
   })),
@@ -81,6 +78,7 @@ async function cleanupRedis() {
   const kstDate = new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10).replace(/-/g, '');
   await redis.del(`quiz:count:${USER_ID}:${kstDate}`);
   await redis.del(`quiz:count:${USER_ID_2}:${kstDate}`);
+  await redis.del(`session:${SESSION_ID}:participants`);
 }
 
 beforeAll(async () => {
@@ -100,10 +98,10 @@ beforeEach(async () => {
   jest.clearAllMocks();
   await cleanupRedis();
 
-  mockSessionFindUnique.mockResolvedValue({ classId: CLASS_ID, status: 'ARCHIVED' });
-  mockClassMemberFindFirst.mockResolvedValue({ id: 'membership-1' });
+  mockSessionFindUnique.mockResolvedValue({ status: 'ARCHIVED' });
   mockQuizQuestionFindFirst.mockResolvedValue({ answer: 'O' });
   mockQuizAnswerUpsert.mockResolvedValue({});
+  await redis.sadd(`session:${SESSION_ID}:participants`, USER_ID, USER_ID_2);
 });
 
 test('오답 제출 후 재응시로 정답 제출 시 isCorrect가 true로 갱신된다', async () => {

--- a/tests/185-quiz-retry-limit.test.js
+++ b/tests/185-quiz-retry-limit.test.js
@@ -19,19 +19,16 @@ const redis = require('../src/lib/redis');
 const PORT = 3103;
 const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-change-me';
 const SESSION_ID = `test-session-185-${Date.now()}`;
-const CLASS_ID = 'test-class-185';
 const VALID_QUESTION_IDS = ['q1', 'q2', 'q3'];
 const INVALID_QUESTION_ID = 'bad-question-id';
 
 const mockSessionFindUnique = jest.fn();
-const mockClassMemberFindFirst = jest.fn();
 const mockQuizQuestionFindFirst = jest.fn();
 const mockQuizAnswerUpsert = jest.fn();
 
 jest.mock('@prisma/client', () => ({
   PrismaClient: jest.fn().mockImplementation(() => ({
     session: { findUnique: mockSessionFindUnique },
-    classMember: { findFirst: mockClassMemberFindFirst },
     quizQuestion: { findFirst: mockQuizQuestionFindFirst },
     quizAnswer: { upsert: mockQuizAnswerUpsert },
   })),
@@ -92,6 +89,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  await redis.del(`session:${SESSION_ID}:participants`);
   ioInstance.close();
   await new Promise((resolve) => serverInstance.close(resolve));
 }, 20000);
@@ -99,8 +97,7 @@ afterAll(async () => {
 beforeEach(() => {
   jest.clearAllMocks();
 
-  mockSessionFindUnique.mockResolvedValue({ classId: CLASS_ID, status: 'ARCHIVED' });
-  mockClassMemberFindFirst.mockResolvedValue({ id: 'membership-1' });
+  mockSessionFindUnique.mockResolvedValue({ status: 'ARCHIVED' });
   mockQuizQuestionFindFirst.mockImplementation(({ where }) =>
     VALID_QUESTION_IDS.includes(where.id) ? Promise.resolve({ answer: 'O' }) : Promise.resolve(null),
   );
@@ -110,6 +107,7 @@ beforeEach(() => {
 test('1. isRetryStart 없이 첫 응시 3문항을 제출해도 daily count가 증가하지 않는다', async () => {
   const userId = `student-185-1-${Date.now()}`;
   const token = makeToken(userId);
+  await redis.sadd(`session:${SESSION_ID}:participants`, userId);
 
   for (const questionId of VALID_QUESTION_IDS) {
     const res = await post(`/sessions/${SESSION_ID}/quiz/submit`, { questionId, answer: 'O' }, token);
@@ -125,6 +123,7 @@ test('1. isRetryStart 없이 첫 응시 3문항을 제출해도 daily count가 �
 test('2~3. 재응시 시작 1회, 2회는 통과하고 3번째 재응시 시작은 429를 반환한다', async () => {
   const userId = `student-185-2-${Date.now()}`;
   const token = makeToken(userId);
+  await redis.sadd(`session:${SESSION_ID}:participants`, userId);
 
   // 1차 재응시 세트 (첫 문항만 isRetryStart:true)
   const retry1 = await post(`/sessions/${SESSION_ID}/quiz/submit`, { questionId: 'q1', answer: 'O', isRetryStart: true }, token);
@@ -147,6 +146,7 @@ test('2~3. 재응시 시작 1회, 2회는 통과하고 3번째 재응시 시작�
 test('4. isRetryStart가 boolean이 아니면 400을 반환한다', async () => {
   const userId = `student-185-4-${Date.now()}`;
   const token = makeToken(userId);
+  await redis.sadd(`session:${SESSION_ID}:participants`, userId);
 
   const res = await post(`/sessions/${SESSION_ID}/quiz/submit`, { questionId: 'q1', answer: 'O', isRetryStart: 'true' }, token);
   expect(res.status).toBe(400);
@@ -157,6 +157,7 @@ test('4. isRetryStart가 boolean이 아니면 400을 반환한다', async () => 
 test('5. 잘못된 questionId로 재응시를 시작하면 404를 반환하고 daily count는 소모되지 않는다', async () => {
   const userId = `student-185-5-${Date.now()}`;
   const token = makeToken(userId);
+  await redis.sadd(`session:${SESSION_ID}:participants`, userId);
 
   const badRes = await post(
     `/sessions/${SESSION_ID}/quiz/submit`,

--- a/tests/quiz-result-participants.test.js
+++ b/tests/quiz-result-participants.test.js
@@ -1,0 +1,113 @@
+/**
+ * GET /sessions/:sessionId/quiz/result 권한 체크 회귀 테스트
+ *
+ * 실행: npx jest tests/quiz-result-participants.test.js --runInBand --forceExit
+ *
+ * 전제: Redis 실행 중
+ * Prisma: jest.mock 처리
+ *
+ * 검증 대상: quiz/result가 ClassMember 대신 session:{sessionId}:participants
+ * Redis Set 기준으로 권한을 확인하는지 확인. QR로 입장해 ClassMember 레코드가 없는
+ * 학생도 participants Set에만 등록돼 있으면 403 없이 조회할 수 있어야 한다.
+ */
+require('dotenv').config();
+
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const redis = require('../src/lib/redis');
+
+const PORT = 3104;
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-change-me';
+const SESSION_ID = `test-session-quiz-result-${Date.now()}`;
+const PARTICIPANT_USER_ID = `test-student-quiz-result-1-${Date.now()}`;
+const NON_PARTICIPANT_USER_ID = `test-student-quiz-result-2-${Date.now()}`;
+
+const mockSessionFindUnique = jest.fn();
+const mockQuizAnswerCount = jest.fn();
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn().mockImplementation(() => ({
+    session: { findUnique: mockSessionFindUnique },
+    quizAnswer: { count: mockQuizAnswerCount },
+  })),
+}));
+
+let serverInstance;
+let ioInstance;
+
+function get(urlPath, token) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: 'localhost',
+        port: PORT,
+        path: urlPath,
+        method: 'GET',
+        headers: {
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+      },
+      (res) => {
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => {
+          const buf = Buffer.concat(chunks);
+          let json = null;
+          try { json = JSON.parse(buf.toString()); } catch (_) {}
+          resolve({ status: res.statusCode, json });
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+function makeToken(userId, role = 'student') {
+  return jwt.sign({ userId, role }, JWT_SECRET, { expiresIn: '1h' });
+}
+
+async function cleanupRedis() {
+  await redis.del(`session:${SESSION_ID}:participants`);
+}
+
+beforeAll(async () => {
+  const { server, io } = require('../src/server');
+  serverInstance = server;
+  ioInstance = io;
+  await new Promise((resolve) => server.listen(PORT, resolve));
+});
+
+afterAll(async () => {
+  await cleanupRedis();
+  ioInstance.close();
+  await new Promise((resolve) => serverInstance.close(resolve));
+}, 20000);
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  await cleanupRedis();
+
+  mockSessionFindUnique.mockResolvedValue({ status: 'ARCHIVED' });
+  mockQuizAnswerCount.mockResolvedValue(2);
+  await redis.sadd(`session:${SESSION_ID}:participants`, PARTICIPANT_USER_ID);
+});
+
+test('QR 입장 학생(ClassMember 없음)도 participants Set에 있으면 403 없이 결과를 조회한다', async () => {
+  const token = makeToken(PARTICIPANT_USER_ID);
+
+  const res = await get(`/sessions/${SESSION_ID}/quiz/result`, token);
+  expect(res.status).toBe(200);
+  expect(res.json.ok).toBe(true);
+  expect(res.json.passed).toBe(true);
+  expect(res.json.correctCount).toBe(2);
+});
+
+test('participants Set에 없는 사용자는 403 NOT_SESSION_MEMBER를 반환한다', async () => {
+  const token = makeToken(NON_PARTICIPANT_USER_ID);
+
+  const res = await get(`/sessions/${SESSION_ID}/quiz/result`, token);
+  expect(res.status).toBe(403);
+  expect(res.json.code).toBe('FORBIDDEN');
+  expect(res.json.message).toBe('NOT_SESSION_MEMBER');
+});


### PR DESCRIPTION
## 📌 Summary

* QR 입장 학생의 퀴즈 제출 및 결과 조회 시 발생하던 403 Forbidden 문제를 수정했습니다.
* `ClassMember` 기반 권한 체크를 제거하고 Redis `participants` Set 기반 권한 체크로 통일했습니다.
* `quiz/result` 회귀 테스트를 추가하고, 기존 퀴즈 관련 테스트를 새로운 권한 체크 방식에 맞게 수정했습니다.

## 🔧 변경 사항

* `POST /sessions/:sessionId/quiz/submit`
  * `ClassMember` 권한 체크 제거
  * Redis `session:{sessionId}:participants` 기반 권한 체크 적용
* `GET /sessions/:sessionId/quiz/result`
  * `ClassMember` 권한 체크 제거
  * Redis `session:{sessionId}:participants` 기반 권한 체크 적용
* 사용하지 않는 `classId` 조회 제거
* 퀴즈 관련 테스트(183, 185) 수정
* `quiz-result-participants` 회귀 테스트 추가

## ✅ 테스트

* `183-quiz-submit-retake.test.js` 통과
* `185-quiz-retry-limit.test.js` 통과
* `quiz-result-participants.test.js` 통과
* QR 입장 학생의 퀴즈 제출 및 결과 조회 정상 동작 확인