### PR TITLE
[Feat]: #189- Google/Kakao 소셜 로그인 기능 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,14 @@ REDIS_URL=redis://localhost:6379
 
 AWS_REGION=ap-northeast-2
 S3_BUCKET_NAME=pentalk-storage
+
+# 소셜 로그인(구글/카카오) — redirect URI는 앱 딥링크가 아니라 백엔드 HTTPS 콜백으로 Provider에 등록
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI=https://{backend-domain}/auth/google/callback
+KAKAO_CLIENT_ID=
+KAKAO_CLIENT_SECRET=
+KAKAO_REDIRECT_URI=https://{backend-domain}/auth/kakao/callback
+APP_CALLBACK_URL=pentalk://auth/callback
+OAUTH_STATE_TTL_SECONDS=300
+OAUTH_CODE_TTL_SECONDS=90

--- a/config/appConfig.js
+++ b/config/appConfig.js
@@ -8,6 +8,11 @@ const APP_CONFIG = {
   SESSION_TTL_SECONDS: Number(process.env.SESSION_TTL_SECONDS) || 21600,
   WHITEBOARD_TTL_AFTER_END: Number(process.env.WHITEBOARD_TTL_AFTER_END) || 600,
   USER_SESSION_CACHE_TTL: Number(process.env.USER_SESSION_CACHE_TTL) || 21600,
+
+  // ✅ 소셜 로그인(구글/카카오)
+  OAUTH_STATE_TTL_SECONDS: Number(process.env.OAUTH_STATE_TTL_SECONDS) || 300, // CSRF용 state, 5분
+  OAUTH_CODE_TTL_SECONDS: Number(process.env.OAUTH_CODE_TTL_SECONDS) || 90,    // 앱 전달용 1회용 코드, 90초
+  APP_CALLBACK_URL: process.env.APP_CALLBACK_URL || 'pentalk://auth/callback', // 앱 딥링크 (고정값, 클라이언트가 지정 불가)
 };
 
 module.exports = { APP_CONFIG };

--- a/config/errors.js
+++ b/config/errors.js
@@ -84,6 +84,15 @@ const ERRORS = {
 
   // ✅ #173: 로그인
   LOGIN_FAILED: "LOGIN_FAILED",
+
+  // ✅ 소셜 로그인(구글/카카오)
+  ROLE_REQUIRED:            "ROLE_REQUIRED",
+  ROLE_ALREADY_SET:         "ROLE_ALREADY_SET",
+  ACCESS_DENIED:            "ACCESS_DENIED",
+  PROVIDER_ERROR:           "PROVIDER_ERROR",
+  INVALID_STATE:            "INVALID_STATE",
+  EMAIL_ALREADY_REGISTERED: "EMAIL_ALREADY_REGISTERED",
+  EXCHANGE_FAILED:          "EXCHANGE_FAILED",
 };
 
 module.exports = { ERRORS };

--- a/config/routes.js
+++ b/config/routes.js
@@ -5,6 +5,14 @@ const ROUTES = {
   AUTH_CHECK_ID: '/auth/check-id',  // ✅ #172 GET
   AUTH_LOGIN:    '/auth/login',     // ✅ #173 POST
 
+  // ✅ 소셜 로그인(구글/카카오)
+  AUTH_GOOGLE:          '/auth/google',          // GET: 인증 시작 (Provider로 리다이렉트)
+  AUTH_GOOGLE_CALLBACK: '/auth/google/callback',  // GET: Provider redirect_uri
+  AUTH_KAKAO:           '/auth/kakao',            // GET: 인증 시작
+  AUTH_KAKAO_CALLBACK:  '/auth/kakao/callback',    // GET: Provider redirect_uri
+  AUTH_EXCHANGE:        '/auth/exchange',          // POST: 1회용 코드 → JWT 교환
+  AUTH_ROLE:            '/auth/role',              // PATCH: 최초 역할 확정
+
   CLASS_CREATE: '/classes',           // ✅ #138 POST
   CLASS_GET:    '/classes/:classId',  // ✅ #138 GET
 

--- a/prisma/migrations/20260705000000_add_social_login_fields/migration.sql
+++ b/prisma/migrations/20260705000000_add_social_login_fields/migration.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "User" ADD COLUMN "provider"   TEXT NOT NULL DEFAULT 'local';
+ALTER TABLE "User" ADD COLUMN "providerId" TEXT;
+ALTER TABLE "User" ADD COLUMN "email"      TEXT;
+ALTER TABLE "User" ALTER COLUMN "role" DROP NOT NULL;
+
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+CREATE UNIQUE INDEX "User_provider_providerId_key" ON "User"("provider", "providerId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,11 +23,16 @@ model User {
   id           String        @id @default(cuid())
   loginId      String?       @unique
   passwordHash String?
+  provider     String        @default("local") // "local" | "google" | "kakao"
+  providerId   String?
+  email        String?       @unique
   name         String?
-  role         String
+  role         String?       // 소셜 로그인 최초 가입 시 역할 선택 전에는 null
   createdAt    DateTime      @default(now())
   classes      Class[]       @relation("TeacherClasses")
   ClassMember  ClassMember[]
+
+  @@unique([provider, providerId])
 }
 
 model Class {

--- a/src/auth/oauthProviders.js
+++ b/src/auth/oauthProviders.js
@@ -1,0 +1,141 @@
+// ✅ 소셜 로그인(구글/카카오): Provider별 인가 URL 생성, 토큰 교환, 프로필 조회
+//
+// 콜백 라우트가 실패 원인을 구분해서 앱에 내려줄 수 있도록,
+// 이 모듈은 실패 시 항상 OAuthProviderError(code)를 던진다.
+// code는 config/errors.js의 ERRORS 값과 1:1로 맞춘다 (ACCESS_DENIED / PROVIDER_ERROR).
+
+const { ERRORS } = require('../../config/errors');
+
+class OAuthProviderError extends Error {
+  constructor(code, message) {
+    super(message || code);
+    this.code = code;
+  }
+}
+
+const PROVIDER_CONFIG = {
+  google: {
+    authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+    tokenUrl: 'https://oauth2.googleapis.com/token',
+    profileUrl: 'https://www.googleapis.com/oauth2/v3/userinfo',
+    scope: 'openid email profile',
+    clientId: () => process.env.GOOGLE_CLIENT_ID,
+    clientSecret: () => process.env.GOOGLE_CLIENT_SECRET,
+    redirectUri: () => process.env.GOOGLE_REDIRECT_URI,
+  },
+  kakao: {
+    authUrl: 'https://kauth.kakao.com/oauth/authorize',
+    tokenUrl: 'https://kauth.kakao.com/oauth/token',
+    profileUrl: 'https://kapi.kakao.com/v2/user/me',
+    scope: 'account_email profile_nickname',
+    clientId: () => process.env.KAKAO_CLIENT_ID,
+    clientSecret: () => process.env.KAKAO_CLIENT_SECRET, // 카카오는 선택 사항(콘솔 설정에 따라 다름)
+    redirectUri: () => process.env.KAKAO_REDIRECT_URI,
+  },
+};
+
+function getProviderConfig(provider) {
+  const config = PROVIDER_CONFIG[provider];
+  if (!config) throw new OAuthProviderError(ERRORS.PROVIDER_ERROR, `UNKNOWN_PROVIDER:${provider}`);
+  // client_id/redirect_uri 없이 진행하면 Provider에 빈 값으로 요청을 보내게 되어
+  // 실패 원인을 알 수 없는 채로 사용자에게만 에러가 노출된다 — 여기서 먼저 명확히 막는다.
+  if (!config.clientId() || !config.redirectUri()) {
+    throw new OAuthProviderError(ERRORS.PROVIDER_ERROR, `OAUTH_ENV_MISSING:${provider}`);
+  }
+  return config;
+}
+
+// Provider 인가 화면 URL 생성 (state는 호출부에서 발급/저장)
+function getAuthorizationUrl(provider, state) {
+  const config = getProviderConfig(provider);
+  const params = new URLSearchParams({
+    client_id: config.clientId() || '',
+    redirect_uri: config.redirectUri() || '',
+    response_type: 'code',
+    scope: config.scope,
+    state,
+  });
+  return `${config.authUrl}?${params.toString()}`;
+}
+
+// Provider 인가 코드를 access token으로 교환
+async function exchangeCodeForToken(provider, code) {
+  const config = getProviderConfig(provider);
+
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: config.clientId() || '',
+    redirect_uri: config.redirectUri() || '',
+    code,
+  });
+  const clientSecret = config.clientSecret();
+  if (clientSecret) body.set('client_secret', clientSecret);
+
+  let res;
+  try {
+    res = await fetch(config.tokenUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+  } catch (e) {
+    throw new OAuthProviderError(ERRORS.PROVIDER_ERROR, 'TOKEN_REQUEST_FAILED');
+  }
+
+  if (!res.ok) {
+    throw new OAuthProviderError(ERRORS.PROVIDER_ERROR, `TOKEN_EXCHANGE_FAILED:${res.status}`);
+  }
+
+  const data = await res.json();
+  if (!data?.access_token) {
+    throw new OAuthProviderError(ERRORS.PROVIDER_ERROR, 'TOKEN_MISSING_IN_RESPONSE');
+  }
+  return data.access_token;
+}
+
+// access token으로 Provider 프로필 조회, { providerId, email, name } 형태로 정규화
+async function fetchProfile(provider, accessToken) {
+  const config = getProviderConfig(provider);
+
+  let res;
+  try {
+    res = await fetch(config.profileUrl, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+  } catch (e) {
+    throw new OAuthProviderError(ERRORS.PROVIDER_ERROR, 'PROFILE_REQUEST_FAILED');
+  }
+
+  if (!res.ok) {
+    throw new OAuthProviderError(ERRORS.PROVIDER_ERROR, `PROFILE_FETCH_FAILED:${res.status}`);
+  }
+
+  const data = await res.json();
+
+  if (provider === 'google') {
+    if (!data?.sub) throw new OAuthProviderError(ERRORS.PROVIDER_ERROR, 'PROFILE_MISSING_SUB');
+    return {
+      providerId: data.sub,
+      email: data.email || null,
+      name: data.name || null,
+    };
+  }
+
+  if (provider === 'kakao') {
+    if (!data?.id) throw new OAuthProviderError(ERRORS.PROVIDER_ERROR, 'PROFILE_MISSING_ID');
+    return {
+      providerId: String(data.id),
+      email: data.kakao_account?.email || null,
+      name: data.kakao_account?.profile?.nickname || null,
+    };
+  }
+
+  throw new OAuthProviderError(ERRORS.PROVIDER_ERROR, `UNKNOWN_PROVIDER:${provider}`);
+}
+
+module.exports = {
+  OAuthProviderError,
+  getAuthorizationUrl,
+  exchangeCodeForToken,
+  fetchProfile,
+};

--- a/src/server.js
+++ b/src/server.js
@@ -14,6 +14,7 @@ const fs = require('fs');
 const { upload, saveFile } = require('./upload/uploadStorage'); // ✅ #93
 const { uploadString, downloadString, getPresignedUrl } = require('./lib/s3'); // ✅ #108
 const bcrypt = require('bcryptjs'); // ✅ #124
+const { getAuthorizationUrl, exchangeCodeForToken, fetchProfile } = require('./auth/oauthProviders'); // ✅ 소셜 로그인
 
 
 if (process.env.NODE_ENV !== "production") {
@@ -779,6 +780,10 @@ app.post('/export/pdf', express.json({ limit: '5mb' }), requireAuth, async (req,
 app.use(express.json());
 app.use(express.static(APP_CONFIG.STATIC_DIR));
 
+// ✅ 소셜 로그인: 역할 미확정 유저에게 발급되는 임시 토큰(scope: role_setup)이
+// 호출할 수 있는 경로. 이 경로 밖에서는 role_setup 토큰과 role이 없는 토큰 모두 차단한다.
+const ROLE_SETUP_ALLOWED_PATHS = new Set([ROUTES.AUTH_ROLE]);
+
 // ✅ #29: HTTP 인증 미들웨어
 function requireAuth(req, res, next) {
   const auth = req.headers.authorization || "";
@@ -793,8 +798,17 @@ function requireAuth(req, res, next) {
     if (!payload?.userId) {
       return sendHttpError(res, 401, ERRORS.UNAUTHORIZED, "INVALID_TOKEN_PAYLOAD");
     }
+
+    // role_setup 임시 토큰이거나(소셜 최초 가입) role이 아예 없는 토큰은
+    // 역할 확정 API 외의 모든 API에서 차단한다.
+    const isRoleSetupToken = payload.scope === "role_setup";
+    if ((isRoleSetupToken || !payload.role) && !ROLE_SETUP_ALLOWED_PATHS.has(req.path)) {
+      return sendHttpError(res, 403, ERRORS.ROLE_REQUIRED, "ROLE_REQUIRED");
+    }
+
     req.userId = payload.userId;
     req.role = payload.role;
+    req.scope = payload.scope;
     next();
   } catch (e) {
     return sendHttpError(res, 401, ERRORS.UNAUTHORIZED, "INVALID_TOKEN");
@@ -1897,6 +1911,189 @@ app.post(ROUTES.AUTH_LOGIN, async (req, res) => {
   }
 });
 
+
+// ✅ 소셜 로그인: 인증 시작 — 프론트가 Custom Tabs/ASWebAuthenticationSession으로 오픈
+// GET /auth/google, GET /auth/kakao
+async function startOAuth(req, res, provider) {
+  try {
+    const state = randomUUID();
+    await redis.set(`oauth:state:${state}`, provider, 'EX', APP_CONFIG.OAUTH_STATE_TTL_SECONDS);
+    return res.redirect(getAuthorizationUrl(provider, state));
+  } catch (err) {
+    logger.error('oauth start failed', { provider, err: err?.message });
+    return sendHttpError(res, 500, ERRORS.PROVIDER_ERROR, 'OAUTH_START_FAILED');
+  }
+}
+app.get(ROUTES.AUTH_GOOGLE, (req, res) => startOAuth(req, res, 'google'));
+app.get(ROUTES.AUTH_KAKAO, (req, res) => startOAuth(req, res, 'kakao'));
+
+// ✅ 소셜 로그인: Provider redirect_uri — Provider가 인가 코드를 실어 이 엔드포인트로 리다이렉트
+// GET /auth/google/callback, GET /auth/kakao/callback
+// state 생성·검증과 Provider 인가 코드 교환은 전부 여기(백엔드)에서 처리하고,
+// 앱에는 JWT 대신 짧은 만료의 1회용 코드만 전달한다.
+async function handleOAuthCallback(req, res, provider) {
+  const { code, state, error: providerError } = req.query;
+
+  const redirectFail = (errorCode) =>
+    res.redirect(`${APP_CONFIG.APP_CALLBACK_URL}?error=${encodeURIComponent(errorCode)}`);
+
+  // Provider가 콜백 쿼리로 에러를 전달한 경우 — 사용자가 동의 화면에서 거부한 것(access_denied)만
+  // ACCESS_DENIED로 구분하고, 그 외 Provider 측 에러(설정 오류 등)는 PROVIDER_ERROR로 처리한다.
+  if (providerError) {
+    logger.info('oauth provider error', { provider, error: providerError });
+    return redirectFail(providerError === 'access_denied' ? ERRORS.ACCESS_DENIED : ERRORS.PROVIDER_ERROR);
+  }
+
+  if (!code || !state || typeof state !== 'string') {
+    return redirectFail(ERRORS.INVALID_STATE);
+  }
+
+  try {
+    const stateKey = `oauth:state:${state}`;
+    const savedProvider = await redis.get(stateKey);
+    if (!savedProvider || savedProvider !== provider) {
+      return redirectFail(ERRORS.INVALID_STATE);
+    }
+    await redis.del(stateKey); // state는 1회용
+
+    const accessToken = await exchangeCodeForToken(provider, code);
+    const profile = await fetchProfile(provider, accessToken);
+
+    let user = await prisma.user.findUnique({
+      where: { provider_providerId: { provider, providerId: profile.providerId } },
+      select: { id: true, role: true },
+    });
+
+    if (!user) {
+      // 소셜 이메일이 기존 local 계정에 이미 쓰이고 있으면 자동 연결하지 않고 거부한다.
+      // (계정 탈취 위험 — 이메일만으로 다른 계정에 슬쩍 연결되면 안 됨)
+      if (profile.email) {
+        const existingByEmail = await prisma.user.findUnique({
+          where: { email: profile.email },
+          select: { id: true },
+        });
+        if (existingByEmail) {
+          return redirectFail(ERRORS.EMAIL_ALREADY_REGISTERED);
+        }
+      }
+
+      user = await prisma.user.create({
+        data: {
+          provider,
+          providerId: profile.providerId,
+          email: profile.email,
+          name: profile.name,
+          role: null,
+        },
+        select: { id: true, role: true },
+      });
+    }
+
+    const oneTimeCode = randomUUID();
+    await redis.set(`oauth:code:${oneTimeCode}`, user.id, 'EX', APP_CONFIG.OAUTH_CODE_TTL_SECONDS);
+
+    return res.redirect(`${APP_CONFIG.APP_CALLBACK_URL}?code=${encodeURIComponent(oneTimeCode)}`);
+  } catch (err) {
+    if (err?.code === 'P2002') {
+      return redirectFail(ERRORS.EMAIL_ALREADY_REGISTERED);
+    }
+    const knownCode = Object.values(ERRORS).includes(err?.code) ? err.code : ERRORS.PROVIDER_ERROR;
+    logger.error('oauth callback failed', { provider, err: err?.message });
+    return redirectFail(knownCode);
+  }
+}
+app.get(ROUTES.AUTH_GOOGLE_CALLBACK, (req, res) => handleOAuthCallback(req, res, 'google'));
+app.get(ROUTES.AUTH_KAKAO_CALLBACK, (req, res) => handleOAuthCallback(req, res, 'kakao'));
+
+// ✅ 소셜 로그인: 1회용 코드 → JWT 교환
+// POST /auth/exchange  Body: { code }
+app.post(ROUTES.AUTH_EXCHANGE, async (req, res) => {
+  const { code } = req.body;
+
+  if (!code || typeof code !== 'string') {
+    return sendHttpError(res, 400, ERRORS.PAYLOAD_INVALID, 'CODE_REQUIRED');
+  }
+
+  try {
+    const codeKey = `oauth:code:${code}`;
+    // GET+DEL은 동시에 같은 code로 요청 두 개가 들어오면 둘 다 GET에 성공할 수 있는 race가 있다.
+    // GETDEL로 조회+폐기를 원자적으로 처리해 code가 정확히 한 번만 소비되게 한다.
+    const userId = await redis.getdel(codeKey);
+    if (!userId) {
+      return sendHttpError(res, 400, ERRORS.EXCHANGE_FAILED, 'CODE_INVALID_OR_EXPIRED');
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, name: true, email: true, role: true, createdAt: true },
+    });
+    if (!user) {
+      return sendHttpError(res, 400, ERRORS.EXCHANGE_FAILED, 'USER_NOT_FOUND');
+    }
+
+    if (!user.role) {
+      const tempToken = signToken({ userId: user.id, role: null, scope: 'role_setup' });
+      logger.info('oauth exchange: role selection required', { userId: user.id });
+      return res.json({
+        requiresRoleSelection: true,
+        token: tempToken,
+        user: { id: user.id, name: user.name, email: user.email, role: user.role, createdAt: user.createdAt },
+      });
+    }
+
+    const token = signToken({ userId: user.id, role: user.role });
+    logger.info('oauth exchange success', { userId: user.id, role: user.role });
+    return res.json({
+      requiresRoleSelection: false,
+      token,
+      user: { id: user.id, name: user.name, email: user.email, role: user.role, createdAt: user.createdAt },
+    });
+  } catch (err) {
+    logger.error('auth exchange failed', { err: err?.message });
+    return sendHttpError(res, 500, ERRORS.EXCHANGE_FAILED, 'EXCHANGE_FAILED');
+  }
+});
+
+// ✅ 소셜 로그인: 최초 역할 확정 (role_setup 임시 토큰으로만 접근 가능하되, 이미 role이 있으면 409)
+// PATCH /auth/role  Header: Authorization: Bearer {role_setup 임시 토큰}  Body: { role }
+app.patch(ROUTES.AUTH_ROLE, requireAuth, async (req, res) => {
+  // requireAuth는 role_setup 토큰이 이 경로를 "지나가게" 허용할 뿐, 일반 토큰도 막지는 않는다
+  // (role이 있는 사용자의 정상 토큰도 통과함). 여기서는 role_setup 임시 토큰만 명시적으로 허용한다.
+  if (req.scope !== 'role_setup') {
+    return sendHttpError(res, 403, ERRORS.FORBIDDEN, 'ROLE_SETUP_TOKEN_REQUIRED');
+  }
+
+  const { role } = req.body;
+
+  if (!role || !['teacher', 'student'].includes(role)) {
+    return sendHttpError(res, 400, ERRORS.PAYLOAD_INVALID, 'INVALID_ROLE');
+  }
+
+  try {
+    // updateMany + count 체크로 "role이 null일 때만 갱신"을 원자적으로 처리한다.
+    // (동시 재시도/중복 요청에도 안전 — 이미 확정된 계정은 무조건 409)
+    const result = await prisma.user.updateMany({
+      where: { id: req.userId, role: null },
+      data: { role },
+    });
+
+    if (result.count === 0) {
+      return sendHttpError(res, 409, ERRORS.ROLE_ALREADY_SET, 'ROLE_ALREADY_SET');
+    }
+
+    const updated = await prisma.user.findUnique({
+      where: { id: req.userId },
+      select: { id: true, name: true, email: true, role: true, createdAt: true },
+    });
+
+    const token = signToken({ userId: updated.id, role: updated.role });
+    logger.info('user role confirmed', { userId: updated.id, role: updated.role });
+    return res.json({ token, user: updated });
+  } catch (err) {
+    logger.error('role confirm failed', { err: err?.message });
+    return sendHttpError(res, 500, ERRORS.INTERNAL_ERROR, 'ROLE_CONFIRM_FAILED');
+  }
+});
 
 app.post(ROUTES.SESSION_CREATE, async (req, res) => {
 const { classId, materialId, title, capacity, password } = req.body;


### PR DESCRIPTION
## 📌 Summary

Google OAuth와 Kakao OAuth 기반 소셜 로그인 기능을 구현했습니다.

신규 사용자는 역할(교사/학생) 선택 후 최종 로그인을 완료할 수 있도록 임시 토큰(role_setup) 기반 플로우를 추가했으며, OAuth 인증 및 보안 처리(state 검증, 1회용 인증 코드)를 적용했습니다.

## 🔧 변경 사항

* User 모델 확장 (provider, providerId, email 추가 및 role nullable 변경)
* Prisma Migration 추가
* Google OAuth 인증 및 Callback 구현
* Kakao OAuth 인증 및 Callback 구현
* OAuth state 생성 및 검증(CSRF 방지)
* Provider Access Token 교환 및 사용자 정보 조회
* 소셜 계정 조회 및 신규 사용자 생성
* 이메일 중복 계정 처리 (자동 연결 방지)
* PenTalk 1회용 인증 코드 생성 및 Redis 기반 관리(GETDEL 적용)
* POST `/auth/exchange` 구현
* 역할 선택용 임시 JWT(role_setup) 발급
* PATCH `/auth/role` 구현 및 역할 확정 후 최종 JWT 재발급
* role 미설정 사용자 접근 제한(ROLE_REQUIRED)
* OAuth 예외 처리 및 오류 코드 추가
* OAuth 관련 환경변수(.env.example) 추가

## ✅ 테스트

* Prisma Migration 적용 및 Prisma Client 재생성 완료
* OAuth 관련 코드 문법 검사(Node.js) 통과
* 기존 퀴즈 관련 테스트(183, 185 등) 통과
* Google/Kakao 실제 OAuth 로그인 테스트는 OAuth Credential(Client ID/Secret) 및 Redirect URI 설정 후 진행 예정
