### PR TITLE
[Fix]: #195-세션 자료 업로드 시 한글 파일명 인코딩 수정

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1186,13 +1186,13 @@ app.post(
         return sendHttpError(res, 403, ERRORS.FORBIDDEN, 'NOT_CLASS_TEACHER');
       }
 
-      const { url } = await saveFile(req, req.file);
+      const { url, name } = await saveFile(req, req.file);
 
       const material = await prisma.material.create({
         data: {
           type: 'pdf',
           url,
-          name: req.file.originalname,
+          name,
           classId,
         },
         select: { id: true, type: true, url: true, name: true, classId: true, createdAt: true },
@@ -2758,7 +2758,7 @@ app.post(
         return sendHttpError(res, 400, ERRORS.PAYLOAD_INVALID, 'SESSION_NOT_ACTIVE');
 
       // 4. 파일 업로드 (트랜잭션 외부 — S3는 롤백 불가)
-      const { url } = await saveFile(req, req.file);
+      const { url, name } = await saveFile(req, req.file);
 
       // 5. Material 생성 + Session 연결을 트랜잭션으로 묶음
       const material = await prisma.$transaction(async (tx) => {
@@ -2766,7 +2766,7 @@ app.post(
           data: {
             type: 'pdf',
             url,
-            name: req.file.originalname,
+            name,
             classId: session.classId,
           },
           select: { id: true, type: true, url: true, name: true, classId: true, createdAt: true },

--- a/src/upload/uploadStorage.js
+++ b/src/upload/uploadStorage.js
@@ -24,7 +24,9 @@ async function saveFile(req, file) {
   // material.url에는 S3 key를 저장 (URL 아님). 조회 시 presigned URL로 변환.
   const key = `pdfs/${req.userId}/${uuidv4()}.pdf`;
   await uploadBuffer(key, file.buffer, 'application/pdf');
-  return { url: key };
+  // multipart/form-data는 파일명 인코딩을 명시하지 않아 multer가 latin1로 디코딩함 -> utf8로 재해석
+  const name = Buffer.from(file.originalname, 'latin1').toString('utf8');
+  return { url: key, name };
 }
 
 const upload = multer({

--- a/tests/93-material-upload-filename-encoding.test.js
+++ b/tests/93-material-upload-filename-encoding.test.js
@@ -1,0 +1,142 @@
+/**
+ * POST /materials/pdf 한글 파일명 인코딩 회귀 테스트
+ *
+ * 실행: npx jest tests/93-material-upload-filename-encoding.test.js --runInBand --forceExit
+ *
+ * multipart/form-data는 파일명 인코딩을 명시하지 않아 multer(busboy)가 기본적으로
+ * latin1로 디코딩한다. 클라이언트가 UTF-8로 보낸 한글 파일명을 그대로 저장하면 깨지므로,
+ * saveFile()이 latin1 -> utf8로 재해석한 이름을 반환하는지 검증한다.
+ *
+ * Prisma, S3: jest.mock 처리
+ */
+require('dotenv').config();
+
+const http = require('http');
+const jwt = require('jsonwebtoken');
+
+const PORT = 3102;
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-change-me';
+const CLASS_ID = 'test-class-93';
+const TEACHER_ID = 'test-teacher-93';
+
+// ── Prisma mock ────────────────────────────────────────────────────────────
+const mockClassFindUnique = jest.fn();
+const mockMaterialCreate = jest.fn();
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn().mockImplementation(() => ({
+    class: { findUnique: mockClassFindUnique },
+    material: { create: mockMaterialCreate },
+  })),
+}));
+
+// ── S3 mock ────────────────────────────────────────────────────────────────
+jest.mock('../src/lib/s3', () => ({
+  uploadBuffer: jest.fn().mockResolvedValue(undefined),
+  uploadString: jest.fn().mockResolvedValue(undefined),
+  downloadString: jest.fn().mockResolvedValue(''),
+  getPresignedUrl: jest.fn().mockResolvedValue('https://example.com/presigned'),
+}));
+
+let serverInstance;
+let ioInstance;
+
+function makeToken(userId = TEACHER_ID, role = 'teacher') {
+  return jwt.sign({ userId, role }, JWT_SECRET, { expiresIn: '1h' });
+}
+
+// multer/busboy가 실제로 겪는 상황을 그대로 재현: 파일명을 UTF-8 바이트로 헤더에 실어 보낸다.
+function postMultipartPdf({ classId, filename, token }) {
+  return new Promise((resolve, reject) => {
+    const boundary = `----jestBoundary${Date.now()}`;
+    const filenameBytes = Buffer.from(filename, 'utf8');
+
+    const preFile = Buffer.from(
+      `--${boundary}\r\n` +
+      `Content-Disposition: form-data; name="classId"\r\n\r\n` +
+      `${classId}\r\n` +
+      `--${boundary}\r\n` +
+      `Content-Disposition: form-data; name="file"; filename="`,
+      'utf8',
+    );
+    const postFile = Buffer.from(
+      `"\r\n` +
+      `Content-Type: application/pdf\r\n\r\n`,
+      'utf8',
+    );
+    const pdfBody = Buffer.from('%PDF-1.4 fake pdf content', 'utf8');
+    const closing = Buffer.from(`\r\n--${boundary}--\r\n`, 'utf8');
+
+    const body = Buffer.concat([preFile, filenameBytes, postFile, pdfBody, closing]);
+
+    const req = http.request(
+      {
+        hostname: 'localhost',
+        port: PORT,
+        path: '/materials/pdf',
+        method: 'POST',
+        headers: {
+          'Content-Type': `multipart/form-data; boundary=${boundary}`,
+          'Content-Length': body.length,
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+      },
+      (res) => {
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => {
+          const buf = Buffer.concat(chunks);
+          let json = null;
+          try { json = JSON.parse(buf.toString()); } catch (_) {}
+          resolve({ status: res.statusCode, json });
+        });
+      },
+    );
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+beforeAll(async () => {
+  const { server, io } = require('../src/server');
+  serverInstance = server;
+  ioInstance = io;
+  await new Promise((resolve) => server.listen(PORT, resolve));
+});
+
+afterAll(async () => {
+  ioInstance.close();
+  await new Promise((resolve) => serverInstance.close(resolve));
+}, 20000);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockClassFindUnique.mockResolvedValue({ id: CLASS_ID, teacherId: TEACHER_ID });
+  mockMaterialCreate.mockImplementation(({ data }) =>
+    Promise.resolve({ id: 'material-93', type: data.type, url: data.url, name: data.name, classId: data.classId, createdAt: new Date() }),
+  );
+});
+
+describe('POST /materials/pdf 파일명 인코딩', () => {
+  test('한글 파일명이 깨지지 않고 그대로 저장됨', async () => {
+    const filename = '수업자료_1주차.pdf';
+
+    const res = await postMultipartPdf({ classId: CLASS_ID, filename, token: makeToken() });
+
+    expect(res.status).toBe(201);
+    expect(res.json?.name).toBe(filename);
+    expect(mockMaterialCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ name: filename }) }),
+    );
+  });
+
+  test('영문 파일명도 그대로 저장됨 (회귀 방지)', async () => {
+    const filename = 'lecture-note-01.pdf';
+
+    const res = await postMultipartPdf({ classId: CLASS_ID, filename, token: makeToken() });
+
+    expect(res.status).toBe(201);
+    expect(res.json?.name).toBe(filename);
+  });
+});


### PR DESCRIPTION
## 📌 Summary

* 세션 자료 업로드 시 한글 파일명이 깨져 저장되는 문제를 수정했습니다.
* 업로드 과정에서 파일명을 `latin1`에서 `utf8`로 재해석하도록 변경했습니다.
* 공통 `saveFile` 함수에서 파일명 디코딩을 수행하도록 개선했습니다.
* 한글/영문 파일명 동작을 검증하는 테스트를 추가했습니다.

## 🔧 변경 사항

* `saveFile`에서 파일명을 UTF-8로 디코딩하여 반환
* 자료 업로드 API에서 디코딩된 파일명을 DB에 저장하도록 변경
* 세션 자료 업로드 API에서 디코딩된 파일명을 DB에 저장하도록 변경
* `93-material-upload-filename-encoding.test.js` 테스트 추가

## ✅ 테스트

* 한글 파일명 업로드 시 정상 저장 확인
* 영문 파일명 업로드 시 정상 저장 확인
* 수정 전 코드에서 파일명 깨짐 재현 확인
* `tests/93-material-upload-filename-encoding.test.js` 통과
* 기존 전체 테스트 실패(44-reconnect, 45-pen-style, 61-export-pdf)는 수정 전과 동일하여 이번 변경과 무관함

Fixes #195